### PR TITLE
[feat][coordinator&store] Add ExecutorMap & CreateTableId,  Speed up create_table

### DIFF
--- a/conf/coordinator.template.yaml
+++ b/conf/coordinator.template.yaml
@@ -1,6 +1,7 @@
 cluster:
   name: dingodb
   instance_id: $INSTANCE_ID$
+  keyring: TO_BE_CONTINUED
 server:
   host: $SERVER_HOST$
   port: $SERVER_PORT$

--- a/conf/coordinator.yaml
+++ b/conf/coordinator.yaml
@@ -1,6 +1,7 @@
 cluster:
   name: dingodb
   instance_id: 23456
+  keyring: TO_BE_CONTINUED
 server:
   host: 127.0.0.1
   port: 19190

--- a/conf/store.template.yaml
+++ b/conf/store.template.yaml
@@ -2,6 +2,7 @@ cluster:
   name: dingodb
   instance_id: $INSTANCE_ID$
   coordinators: $COORDINATOR_SERVICE_PEERS$
+  keyring: TO_BE_CONTINUED
 server:
   host: $SERVER_HOST$
   port: $SERVER_PORT$

--- a/conf/store.template.yaml
+++ b/conf/store.template.yaml
@@ -7,6 +7,7 @@ server:
   host: $SERVER_HOST$
   port: $SERVER_PORT$
   heartbeatInterval: 10000 # ms
+  pushInterval: 1000 # ms
 raft:
   host: $RAFT_HOST$
   port: $RAFT_PORT$

--- a/conf/store.yaml
+++ b/conf/store.yaml
@@ -2,6 +2,7 @@ cluster:
   name: dingodb
   instance_id: 12345
   coordinators: 127.0.0.1:19190,127.0.0.1:19191,127.0.0.1:19192
+  keyring: TO_BE_CONTINUED
 server:
   host: 127.0.0.1
   port: 23000

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -63,6 +63,12 @@ enum StoreState {
   STORE_OUT = 3;      // up but no data will distribute to this store
 }
 
+enum ExecutorState {
+  EXECUTOR_NORMAL = 0;
+  EXECUTOR_NEW = 1;      // a new store, wait to startup and join raft
+  EXECUTOR_OFFLINE = 2;  // miss hearteat
+}
+
 enum RegionState {
   REGION_NORMAL = 0;
 
@@ -97,6 +103,21 @@ message CoordinatorMap {
   repeated Coordinator coordinators = 2;
 }
 
+message Executor {
+  uint64 id = 1;
+  uint64 epoch = 2;
+  ExecutorState state = 3;
+  Location server_location = 4;
+  Location raft_location = 5;
+  string resource_tag = 6;
+  string keyring = 7;
+}
+
+message ExecutorMap {
+  uint64 epoch = 1;
+  repeated Executor executors = 2;
+}
+
 message Store {
   uint64 id = 1;
   uint64 epoch = 2;
@@ -104,6 +125,7 @@ message Store {
   Location server_location = 4;
   Location raft_location = 5;
   string resource_tag = 6;
+  string keyring = 7;
 }
 
 message StoreMap {

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -108,9 +108,8 @@ message Executor {
   uint64 epoch = 2;
   ExecutorState state = 3;
   Location server_location = 4;
-  Location raft_location = 5;
-  string resource_tag = 6;
-  string keyring = 7;
+  string resource_tag = 5;
+  string keyring = 6;
 }
 
 message ExecutorMap {

--- a/proto/coordinator.proto
+++ b/proto/coordinator.proto
@@ -38,6 +38,17 @@ message StoreHeartbeatResponse {
   dingodb.pb.common.RegionMap regionmap = 5;  // new regionmap
 }
 
+message ExecutorHeartbeatRequest {
+  uint64 self_executormap_epoch = 1;        // executormap epoch in this Executor
+  dingodb.pb.common.Executor executor = 2;  // self executor info
+}
+
+message ExecutorHeartbeatResponse {
+  dingodb.pb.error.Error error = 1;
+  uint64 executormap_epoch = 2;                   // the lates epoch of executormap
+  dingodb.pb.common.ExecutorMap executormap = 3;  // new executormap
+}
+
 message HelloRequest {
   uint64 hello = 1;
 }
@@ -75,7 +86,7 @@ message CreateStoreRequest {
 message CreateStoreResponse {
   dingodb.pb.error.Error error = 1;
   uint64 store_id = 2;
-  string password = 3;
+  string keyring = 3;
 }
 
 message GetCoordinatorMapRequest {
@@ -88,6 +99,46 @@ message GetCoordinatorMapResponse {
   repeated dingodb.pb.common.Location coordinator_locations = 3;
 }
 
+message DeleteStoreRequest {
+  uint64 cluster_id = 1;
+  uint64 store_id = 2;
+  string keyring = 3;
+}
+
+message DeleteStoreResponse {
+  dingodb.pb.error.Error error = 1;
+}
+
+message CreateExecutorRequest {
+  uint64 cluster_id = 1;
+}
+
+message CreateExecutorResponse {
+  dingodb.pb.error.Error error = 1;
+  uint64 executor_id = 2;
+  string keyring = 3;
+}
+
+message DeleteExecutorRequest {
+  uint64 cluster_id = 1;
+  uint64 executor_id = 2;
+  string keyring = 3;
+}
+
+message DeleteExecutorResponse {
+  dingodb.pb.error.Error error = 1;
+}
+
+message GetExecutorMapRequest {
+  uint64 epoch = 1;
+}
+
+message GetExecutorMapResponse {
+  dingodb.pb.error.Error error = 1;
+  uint64 epoch = 2;
+  dingodb.pb.common.ExecutorMap executormap = 3;
+}
+
 service CoordinatorService {
   // Hello
   rpc Hello(HelloRequest) returns (HelloResponse);
@@ -98,6 +149,13 @@ service CoordinatorService {
   rpc GetStoreMap(GetStoreMapRequest) returns (GetStoreMapResponse);
 
   rpc CreateStore(CreateStoreRequest) returns (CreateStoreResponse);
+  rpc DeleteStore(DeleteStoreRequest) returns (DeleteStoreResponse);
+
+  // Executor
+  rpc ExecutorHeartbeat(ExecutorHeartbeatRequest) returns (ExecutorHeartbeatResponse);
+  rpc CreateExecutor(CreateExecutorRequest) returns (CreateExecutorResponse);
+  rpc DeleteExecutor(DeleteExecutorRequest) returns (DeleteExecutorResponse);
+  rpc GetExecutorMap(GetExecutorMapRequest) returns (GetExecutorMapResponse);
 
   // Coordinator
   rpc GetCoordinatorMap(GetCoordinatorMapRequest) returns (GetCoordinatorMapResponse);

--- a/proto/coordinator_internal.proto
+++ b/proto/coordinator_internal.proto
@@ -58,6 +58,9 @@ enum IdEpochType {
   EPOCH_SCHEMA = 7;
   EPOCH_REGION = 8;
   EPOCH_TABLE = 9;
+
+  ID_NEXT_EXECUTOR = 10;
+  EPOCH_EXECUTOR = 11;
 }
 
 message IdEpochInternal {
@@ -84,6 +87,12 @@ message MetaIncrementCoordinator {
 message MetaIncrementStore {
   uint64 id = 1;
   dingodb.pb.common.Store store = 2;
+  MetaIncrementOpType op_type = 3;
+}
+
+message MetaIncrementExecutor {
+  uint64 id = 1;
+  dingodb.pb.common.Executor executor = 2;
   MetaIncrementOpType op_type = 3;
 }
 
@@ -122,4 +131,5 @@ message MetaIncrement {
   repeated MetaIncrementSchema schemas = 4;
   repeated MetaIncrementTable tables = 5;
   repeated MetaIncrementIdEpoch idepochs = 6;
+  repeated MetaIncrementExecutor executors = 7;
 }

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -187,9 +187,19 @@ message GetTableResponse {
   Table table = 2;
 }
 
+message CreateTableIdRequest {
+  DingoCommonId schema_id = 1;
+}
+
+message CreateTableIdResponse {
+  dingodb.pb.error.Error error = 1;
+  DingoCommonId table_id = 2;
+}
+
 message CreateTableRequest {
   DingoCommonId schema_id = 1;
-  TableDefinition table_definition = 2;
+  DingoCommonId table_id = 2;
+  TableDefinition table_definition = 3;
 }
 
 message CreateTableResponse {
@@ -231,8 +241,14 @@ service MetaService {
   // out: Table
   rpc GetTable(GetTableRequest) returns (GetTableResponse);
 
+  // CreateTableId
+  // in: schema_id
+  // out: table_id
+  rpc CreateTableId(CreateTableIdRequest) returns (CreateTableIdResponse);
+
   // CreateTable
-  // in: schema_id TableDefinition
+  // in: schema_id table_id TableDefinition
+  //      if table_id is specified, use given table_id, else create new table_id
   // out: table_id
   rpc CreateTable(CreateTableRequest) returns (CreateTableResponse);
 

--- a/src/client/coordinator_client.cc
+++ b/src/client/coordinator_client.cc
@@ -113,6 +113,26 @@ void SendGetStoreMap(brpc::Controller& cntl, dingodb::pb::coordinator::Coordinat
   }
 }
 
+void SendGetExecutorMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+  dingodb::pb::coordinator::GetExecutorMapRequest request;
+  dingodb::pb::coordinator::GetExecutorMapResponse response;
+
+  request.set_epoch(1);
+
+  stub.GetExecutorMap(&cntl, &request, &response, nullptr);
+  if (cntl.Failed()) {
+    LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
+    // bthread_usleep(FLAGS_timeout_ms * 1000L);
+  }
+
+  if (FLAGS_log_each_request) {
+    LOG(INFO) << "Received response"
+              << " get_executor_map=" << request.epoch() << " request_attachment=" << cntl.request_attachment().size()
+              << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
+    LOG(INFO) << response.DebugString();
+  }
+}
+
 void SendGetCoordinatorMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
   dingodb::pb::coordinator::GetCoordinatorMapRequest request;
   dingodb::pb::coordinator::GetCoordinatorMapResponse response;
@@ -154,6 +174,7 @@ void SendGetRegionMap(brpc::Controller& cntl, dingodb::pb::coordinator::Coordina
     LOG(INFO) << response.DebugString();
   }
 }
+
 void SendCreateStore(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
   dingodb::pb::coordinator::CreateStoreRequest request;
   dingodb::pb::coordinator::CreateStoreResponse response;
@@ -168,6 +189,74 @@ void SendCreateStore(brpc::Controller& cntl, dingodb::pb::coordinator::Coordinat
   if (FLAGS_log_each_request) {
     LOG(INFO) << "Received response"
               << " create store cluster_id =" << request.cluster_id()
+              << " request_attachment=" << cntl.request_attachment().size()
+              << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
+    LOG(INFO) << response.DebugString();
+  }
+}
+
+void SendDeleteStore(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+  dingodb::pb::coordinator::DeleteStoreRequest request;
+  dingodb::pb::coordinator::DeleteStoreResponse response;
+
+  request.set_cluster_id(1);
+  request.set_store_id(101);
+  auto* keyring = request.mutable_keyring();
+  keyring->assign("aabbcc");
+
+  stub.DeleteStore(&cntl, &request, &response, nullptr);
+  if (cntl.Failed()) {
+    LOG(WARNING) << "Fail to send request to : " << cntl.ErrorCode() << "[" << cntl.ErrorText() << "]";
+    // bthread_usleep(FLAGS_timeout_ms * 1000L);
+  }
+
+  if (FLAGS_log_each_request) {
+    LOG(INFO) << "Received response"
+              << " create store cluster_id =" << request.cluster_id()
+              << " request_attachment=" << cntl.request_attachment().size()
+              << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
+    LOG(INFO) << response.DebugString();
+  }
+}
+
+void SendCreateExecutor(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+  dingodb::pb::coordinator::CreateExecutorRequest request;
+  dingodb::pb::coordinator::CreateExecutorResponse response;
+
+  request.set_cluster_id(1);
+  stub.CreateExecutor(&cntl, &request, &response, nullptr);
+  if (cntl.Failed()) {
+    LOG(WARNING) << "Fail to send request to : " << cntl.ErrorCode() << "[" << cntl.ErrorText() << "]";
+    // bthread_usleep(FLAGS_timeout_ms * 1000L);
+  }
+
+  if (FLAGS_log_each_request) {
+    LOG(INFO) << "Received response"
+              << " create executor cluster_id =" << request.cluster_id()
+              << " request_attachment=" << cntl.request_attachment().size()
+              << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
+    LOG(INFO) << response.DebugString();
+  }
+}
+
+void SendDeleteExecutor(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+  dingodb::pb::coordinator::DeleteExecutorRequest request;
+  dingodb::pb::coordinator::DeleteExecutorResponse response;
+
+  request.set_cluster_id(1);
+  request.set_executor_id(101);
+  auto* keyring = request.mutable_keyring();
+  keyring->assign("aabbcc");
+
+  stub.DeleteExecutor(&cntl, &request, &response, nullptr);
+  if (cntl.Failed()) {
+    LOG(WARNING) << "Fail to send request to : " << cntl.ErrorCode() << "[" << cntl.ErrorText() << "]";
+    // bthread_usleep(FLAGS_timeout_ms * 1000L);
+  }
+
+  if (FLAGS_log_each_request) {
+    LOG(INFO) << "Received response"
+              << " create executor cluster_id =" << request.cluster_id()
               << " request_attachment=" << cntl.request_attachment().size()
               << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
     LOG(INFO) << response.DebugString();
@@ -277,8 +366,16 @@ void* Sender(void* /*arg*/) {
       SendStoreHearbeat(cntl, stub, 300);
     } else if (FLAGS_method == "CreateStore") {
       SendCreateStore(cntl, stub);
+    } else if (FLAGS_method == "DeleteStore") {
+      SendDeleteStore(cntl, stub);
+    } else if (FLAGS_method == "CreateExecutor") {
+      SendCreateExecutor(cntl, stub);
+    } else if (FLAGS_method == "DeleteExecutor") {
+      SendDeleteExecutor(cntl, stub);
     } else if (FLAGS_method == "GetStoreMap") {
       SendGetStoreMap(cntl, stub);
+    } else if (FLAGS_method == "GetExecutorMap") {
+      SendGetExecutorMap(cntl, stub);
     } else if (FLAGS_method == "GetRegionMap") {
       SendGetRegionMap(cntl, stub);
     } else if (FLAGS_method == "GetCoordinatorMap") {

--- a/src/client/meta_client.cc
+++ b/src/client/meta_client.cc
@@ -122,7 +122,7 @@ void SendGetTable(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& s
   auto* table_id = request.mutable_table_id();
   table_id->set_entity_type(::dingodb::pb::meta::EntityType::ENTITY_TYPE_TABLE);
   table_id->set_parent_entity_id(::dingodb::pb::meta::ReservedSchemaIds::DINGO_SCHEMA);
-  table_id->set_entity_id(101);
+  table_id->set_entity_id(1001);
 
   stub.GetTable(&cntl, &request, &response, nullptr);
   if (cntl.Failed()) {

--- a/src/common/helper.cc
+++ b/src/common/helper.cc
@@ -14,6 +14,7 @@
 
 #include "common/helper.h"
 
+#include <cstdint>
 #include <regex>
 
 #include "brpc/controller.h"
@@ -206,7 +207,7 @@ std::string Helper::Increment(const std::string& input) {
   std::string ret(input.size(), 0);
   int carry = 1;
   for (int i = input.size() - 1; i >= 0; --i) {
-    if (input[i] == 0xFF && carry == 1) {
+    if (static_cast<int32_t>(input[i]) == 0xFF && carry == 1) {
       ret[i] = 0;
     } else {
       ret[i] = (input[i] + carry);

--- a/src/common/helper.cc
+++ b/src/common/helper.cc
@@ -311,4 +311,18 @@ void Helper::GetServerLocation(const pb::common::Location& raft_location, pb::co
   server_location.CopyFrom(response.node_info().server_location());
 }
 
+std::string Helper::generateRandomString(int length) {
+  std::string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  std::string randString = "";
+
+  unsigned int seed = time(0);  // Get seed value for rand_r()
+
+  for (int i = 0; i < length; i++) {
+    int randIndex = rand_r(&seed) % chars.size();
+    randString += chars[randIndex];
+  }
+
+  return randString;
+}
+
 }  // namespace dingodb

--- a/src/common/helper.h
+++ b/src/common/helper.h
@@ -114,6 +114,9 @@ class Helper {
   // in: raft_location
   // out: server_location
   static void GetServerLocation(const pb::common::Location& raft_location, pb::common::Location& server_location);
+
+  // generate random string for keyring
+  static std::string generateRandomString(int length);
 };
 
 }  // namespace dingodb

--- a/src/common/meta_control.h
+++ b/src/common/meta_control.h
@@ -76,10 +76,29 @@ class MetaControl {
 
   // create store
   // in: cluster_id
-  // out: store_id, password
+  // out: store_id, keyring
   // return: 0 or -1
-  virtual int CreateStore(uint64_t cluster_id, uint64_t &store_id, std::string &password,
+  virtual int CreateStore(uint64_t cluster_id, uint64_t &store_id, std::string &keyring,
                           pb::coordinator_internal::MetaIncrement &meta_increment) = 0;
+
+  // delete store
+  // in: cluster_id, store_id, keyring
+  // return: 0 or -1
+  virtual int DeleteStore(uint64_t cluster_id, uint64_t store_id, std::string keyring,
+                          pb::coordinator_internal::MetaIncrement &meta_increment) = 0;
+
+  // create executor
+  // in: cluster_id
+  // out: executor_id, keyring
+  // return: 0 or -1
+  virtual int CreateExecutor(uint64_t cluster_id, uint64_t &executor_id, std::string &keyring,
+                             pb::coordinator_internal::MetaIncrement &meta_increment) = 0;
+
+  // delete executor
+  // in: cluster_id, executor_id, keyring
+  // return: 0 or -1
+  virtual int DeleteExecutor(uint64_t cluster_id, uint64_t executor_id, std::string keyring,
+                             pb::coordinator_internal::MetaIncrement &meta_increment) = 0;
 
   // update store map with new Store info
   // return new epoch

--- a/src/coordinator/coordinator_control.cc
+++ b/src/coordinator/coordinator_control.cc
@@ -57,6 +57,7 @@ CoordinatorControl::~CoordinatorControl() {
   delete region_meta_;
   delete table_meta_;
   delete id_epoch_meta_;
+  delete executor_meta_;
 }
 
 bool CoordinatorControl::IsLeader() { return is_leader_.load(); }

--- a/src/coordinator/coordinator_control.h
+++ b/src/coordinator/coordinator_control.h
@@ -189,6 +189,13 @@ class CoordinatorControl : public MetaControl {
 
   // create schema
   // in: schema_id
+  // out: new table_id
+  // return: 0 or -1
+  int CreateTableId(uint64_t schema_id, uint64_t &new_table_id,
+                    pb::coordinator_internal::MetaIncrement &meta_increment);
+
+  // create schema
+  // in: schema_id
   // in: table_definition
   // out: new table_id
   // return: 0 or -1

--- a/src/meta/coordinator_meta_manager.cc
+++ b/src/meta/coordinator_meta_manager.cc
@@ -21,12 +21,12 @@
 
 namespace dingodb {
 
-CoordinatorServerMeta::CoordinatorServerMeta() : store_(std::make_shared<pb::common::Coordinator>()) {}
+CoordinatorServerMeta::CoordinatorServerMeta() : coordinator_(std::make_shared<pb::common::Coordinator>()) {}
 
 bool CoordinatorServerMeta::Init() {
   auto* server = Server::GetInstance();
-  store_->set_id(server->Id());
-  LOG(INFO) << "store server meta: " << store_->ShortDebugString();
+  coordinator_->set_id(server->Id());
+  LOG(INFO) << "coordinator server meta: " << coordinator_->ShortDebugString();
 
   return true;
 }
@@ -39,38 +39,40 @@ CoordinatorServerMeta& CoordinatorServerMeta::SetEpoch(uint64_t epoch) {
 }
 
 CoordinatorServerMeta& CoordinatorServerMeta::SetId(uint64_t id) {
-  store_->set_id(id);
+  coordinator_->set_id(id);
   return *this;
 }
 
 CoordinatorServerMeta& CoordinatorServerMeta::SetState(pb::common::CoordinatorState state) {
-  store_->set_state(state);
+  coordinator_->set_state(state);
   return *this;
 }
 
 CoordinatorServerMeta& CoordinatorServerMeta::SetServerLocation(const butil::EndPoint&& /*endpoint*/) {
-  //   auto* location = store_->mutable_server_location();
+  //   auto* location = coordinator_->mutable_server_location();
   //   location->set_host(butil::ip2str(endpoint.ip).c_str());
   //   location->set_port(endpoint.port);
   return *this;
 }
 
 CoordinatorServerMeta& CoordinatorServerMeta::SetRaftLocation(const butil::EndPoint&& /*endpoint*/) {
-  //   auto* location = store_->mutable_raft_location();
+  //   auto* location = coordinator_->mutable_raft_location();
   //   location->set_host(butil::ip2str(endpoint.ip).c_str());
   //   location->set_port(endpoint.port);
   return *this;
 }
 
-std::shared_ptr<pb::common::Coordinator> CoordinatorServerMeta::GetCoordinator() { return store_; }
+std::shared_ptr<pb::common::Coordinator> CoordinatorServerMeta::GetCoordinator() { return coordinator_; }
 
 CoordinatorMetaManager::CoordinatorMetaManager(std::shared_ptr<MetaReader> meta_reader,
                                                std::shared_ptr<MetaWriter> meta_writer)
     : meta_reader_(meta_reader),
       meta_writer_(meta_writer),
       server_meta_(std::make_unique<CoordinatorServerMeta>()),
+      idepoch_meta_(std::make_unique<CoordinatorMap<pb::coordinator_internal::IdEpochInternal>>()),
       coordinator_meta_(std::make_unique<CoordinatorMap<pb::coordinator_internal::CoordinatorInternal>>()),
       store_meta_(std::make_unique<CoordinatorMap<pb::common::Store>>()),
+      executor_meta_(std::make_unique<CoordinatorMap<pb::common::Executor>>()),
       schema_meta_(std::make_unique<CoordinatorMap<pb::meta::Schema>>()),
       region_meta_(std::make_unique<CoordinatorMap<pb::common::Region>>()),
       table_meta_(std::make_unique<CoordinatorMap<pb::coordinator_internal::TableInternal>>()) {}

--- a/src/meta/coordinator_meta_manager.h
+++ b/src/meta/coordinator_meta_manager.h
@@ -51,7 +51,7 @@ class CoordinatorServerMeta {
 
  private:
   uint64_t epoch_;
-  std::shared_ptr<pb::common::Coordinator> store_;
+  std::shared_ptr<pb::common::Coordinator> coordinator_;
 };
 
 template <typename T>
@@ -150,7 +150,7 @@ class CoordinatorMap {
   std::map<uint64_t, T> elements_;
 };
 
-// Manage store server meta data, like store and region.
+// Manage server meta data
 // the data will report periodic.
 class CoordinatorMetaManager {
  public:
@@ -175,8 +175,10 @@ class CoordinatorMetaManager {
   std::unique_ptr<CoordinatorServerMeta> server_meta_;
 
   // Coordinator maps
+  std::unique_ptr<CoordinatorMap<pb::coordinator_internal::IdEpochInternal>> idepoch_meta_;
   std::unique_ptr<CoordinatorMap<pb::coordinator_internal::CoordinatorInternal>> coordinator_meta_;
   std::unique_ptr<CoordinatorMap<pb::common::Store>> store_meta_;
+  std::unique_ptr<CoordinatorMap<pb::common::Executor>> executor_meta_;
   std::unique_ptr<CoordinatorMap<pb::meta::Schema>> schema_meta_;
   std::unique_ptr<CoordinatorMap<pb::common::Region>> region_meta_;
   std::unique_ptr<CoordinatorMap<pb::coordinator_internal::TableInternal>> table_meta_;

--- a/src/meta/store_meta_manager.cc
+++ b/src/meta/store_meta_manager.cc
@@ -28,6 +28,7 @@ bool StoreServerMeta::Init() {
 
   std::shared_ptr<pb::common::Store> store = std::make_shared<pb::common::Store>();
   store->set_id(server->Id());
+  store->mutable_keyring()->assign(server->Keyring());
   store->set_epoch(0);
   store->set_state(pb::common::STORE_NORMAL);
   auto* server_location = store->mutable_server_location();

--- a/src/raft/store_state_machine.cc
+++ b/src/raft/store_state_machine.cc
@@ -188,6 +188,10 @@ void StoreStateMachine::on_leader_start(int64_t term) {
   auto region = store_meta_manager->GetRegion(node_id_);
   region->set_leader_store_id(Server::GetInstance()->Id());
   region->set_state(pb::common::REGION_NORMAL);
+
+  // trigger heartbeat
+  auto store_control = Server::GetInstance()->GetStoreControl();
+  store_control->TriggerHeartbeat();
 }
 
 void StoreStateMachine::on_leader_stop(const butil::Status& status) {

--- a/src/server/coordinator_service.h
+++ b/src/server/coordinator_service.h
@@ -53,8 +53,25 @@ class CoordinatorServiceImpl : public pb::coordinator::CoordinatorService {
                     pb::coordinator::GetRegionMapResponse* response, google::protobuf::Closure* done) override;
   void GetStoreMap(google::protobuf::RpcController* controller, const pb::coordinator::GetStoreMapRequest* request,
                    pb::coordinator::GetStoreMapResponse* response, google::protobuf::Closure* done) override;
+
   void CreateStore(google::protobuf::RpcController* controller, const pb::coordinator::CreateStoreRequest* request,
                    pb::coordinator::CreateStoreResponse* response, google::protobuf::Closure* done) override;
+  void DeleteStore(google::protobuf::RpcController* controller, const pb::coordinator::DeleteStoreRequest* request,
+                   pb::coordinator::DeleteStoreResponse* response, google::protobuf::Closure* done) override;
+
+  void ExecutorHeartbeat(google::protobuf::RpcController* controller,
+                         const pb::coordinator::ExecutorHeartbeatRequest* request,
+                         pb::coordinator::ExecutorHeartbeatResponse* response,
+                         google::protobuf::Closure* done) override;
+  void CreateExecutor(google::protobuf::RpcController* controller,
+                      const pb::coordinator::CreateExecutorRequest* request,
+                      pb::coordinator::CreateExecutorResponse* response, google::protobuf::Closure* done) override;
+  void DeleteExecutor(google::protobuf::RpcController* controller,
+                      const pb::coordinator::DeleteExecutorRequest* request,
+                      pb::coordinator::DeleteExecutorResponse* response, google::protobuf::Closure* done) override;
+  void GetExecutorMap(google::protobuf::RpcController* controller,
+                      const pb::coordinator::GetExecutorMapRequest* request,
+                      pb::coordinator::GetExecutorMapResponse* response, google::protobuf::Closure* done) override;
 
   void GetCoordinatorMap(google::protobuf::RpcController* controller,
                          const pb::coordinator::GetCoordinatorMapRequest* request,

--- a/src/server/meta_service.h
+++ b/src/server/meta_service.h
@@ -54,6 +54,8 @@ class MetaServiceImpl : public pb::meta::MetaService {
                    pb::meta::CreateTableResponse* response, google::protobuf::Closure* done) override;
   void DropTable(google::protobuf::RpcController* controller, const pb::meta::DropTableRequest* request,
                  pb::meta::DropTableResponse* response, google::protobuf::Closure* done) override;
+  void CreateTableId(google::protobuf::RpcController* controller, const pb::meta::CreateTableIdRequest* request,
+                     pb::meta::CreateTableIdResponse* response, google::protobuf::Closure* done) override;
 
   void CreateSchema(google::protobuf::RpcController* controller, const pb::meta::CreateSchemaRequest* request,
                     pb::meta::CreateSchemaResponse* response, google::protobuf::Closure* done) override;

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -80,7 +80,8 @@ bool Server::InitLog() {
 bool Server::InitServerID() {
   auto config = ConfigManager::GetInstance()->GetConfig(role_);
   id_ = config->GetInt("cluster.instance_id");
-  return id_ != 0;
+  keyring_ = config->GetString("cluster.keyring");
+  return id_ != 0 && (!keyring_.empty());
 }
 
 bool Server::InitRawEngines() {

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -16,6 +16,7 @@
 #define DINGODB_STORE_SERVER_H_
 
 #include <memory>
+#include <string>
 
 #include "brpc/channel.h"
 #include "common/meta_control.h"
@@ -85,6 +86,7 @@ class Server {
   void Destroy();
 
   uint64_t Id() const { return id_; }
+  std::string Keyring() const { return keyring_; }
 
   butil::EndPoint ServerEndpoint() { return server_endpoint_; }
   void SetServerEndpoint(const butil::EndPoint& endpoint) { server_endpoint_ = endpoint; }
@@ -119,6 +121,8 @@ class Server {
   // represent store's identity, provided by coordinator.
   // read from store config file.
   uint64_t id_;
+  // This is keyring, the password for this instance to join in the cluster
+  std::string keyring_;
   // Role, include store/coordinator
   pb::common::ClusterRole role_;
   // Service ip and port.

--- a/src/store/heartbeat.cc
+++ b/src/store/heartbeat.cc
@@ -23,6 +23,7 @@
 #include "proto/common.pb.h"
 #include "proto/coordinator.pb.h"
 #include "proto/push.pb.h"
+#include "server/server.h"
 
 namespace dingodb {
 
@@ -108,8 +109,15 @@ void Heartbeat::SendCoordinatorPushToStore(void* arg) {
 }
 
 void Heartbeat::SendStoreHeartbeat(void* arg) {
-  LOG(INFO) << "SendStoreHeartbeat...";
+  // LOG(INFO) << "SendStoreHeartbeat...";
   CoordinatorInteraction* coordinator_interaction = static_cast<CoordinatorInteraction*>(arg);
+
+  auto store_control = Server::GetInstance()->GetStoreControl();
+  if (!store_control->CheckNeedToHeartbeat()) {
+    // LOG(INFO) << "CheckNeedToHeartbeat is false, no need to hearbeat";
+    return;
+  }
+  LOG(INFO) << "CheckNeedToHeartbeat is true, start to SendStoreHeartbeat";
 
   pb::coordinator::StoreHeartbeatRequest request;
   auto store_meta = Server::GetInstance()->GetStoreMetaManager();

--- a/src/store/store_control.cc
+++ b/src/store/store_control.cc
@@ -156,4 +156,32 @@ butil::Status StoreControl::DeleteRegion(std::shared_ptr<Context> ctx, uint64_t 
   return butil::Status();
 }
 
+void StoreControl::SetHeartbeatIntervalMultiple(uint64_t interval_multiple) {
+  this->heartbeat_interval_multiple = interval_multiple;
+}
+
+void StoreControl::TriggerHeartbeat() {
+  LOG(INFO) << "TriggerHeartbeat";
+  this->need_heartbeat_immediately.store(true);
+}
+
+bool StoreControl::CheckNeedToHeartbeat() {
+  if (this->need_heartbeat_immediately.load()) {
+    this->need_heartbeat_immediately.store(false);
+    this->heartbeat_count = 0;
+
+    LOG(INFO) << "Heartbeat is triggerred";
+    return true;
+  }
+
+  this->heartbeat_count++;
+
+  if (this->heartbeat_count >= this->heartbeat_interval_multiple) {
+    this->heartbeat_count = 0;
+    return true;
+  }
+
+  return false;
+}
+
 }  // namespace dingodb

--- a/src/store/store_control.h
+++ b/src/store/store_control.h
@@ -15,6 +15,8 @@
 #ifndef DINGODB_STORE_STORE_CONTROL_H_
 #define DINGODB_STORE_STORE_CONTROL_H_
 
+#include <atomic>
+#include <cstdint>
 #include <memory>
 
 #include "butil/macros.h"
@@ -36,8 +38,19 @@ class StoreControl {
   butil::Status ChangeRegion(std::shared_ptr<Context> ctx, std::shared_ptr<pb::common::Region> region);
   butil::Status DeleteRegion(std::shared_ptr<Context> ctx, uint64_t region_id);
 
+  void SetHeartbeatIntervalMultiple(uint64_t interval_multiple);
+  void TriggerHeartbeat();
+
+  // return true if need to send heartbeat
+  bool CheckNeedToHeartbeat();
+
+  std::atomic_bool need_send_heartbeat_immediately;
+
  private:
   bthread_mutex_t control_mutex_;
+  std::atomic_bool need_heartbeat_immediately;  // this value is true mean heartbeat is neeed immediately
+  uint64_t heartbeat_interval_multiple;         // this value describe N times the heartbeat_interval to push_interval
+  uint64_t heartbeat_count;                     // this value store heartbeat executed count
 };
 
 }  // namespace dingodb


### PR DESCRIPTION
[feat][coordinator]  Add ExecutorMap, add keyring validate for executor
and store.
During develop stage, we can use a super password keyring
TO_BE_CONTINUED to bypass keyring check.

[fix][common] Fix a char compare with integer bug in Helper::Increment.

[feat][coordinator] Add CreateTableId rpc call for SDK.
SDK needs get table_id to generate the range of partitions, so SDK can
now call CreateTableId to get a legal table_id, and then use this
table_id to create table.

[feat][store] Trigger immediately heartbeat after on_leader_start.
Now create table will finish in less than 5 seconds.
