### PR TITLE
[fix][dingo-mysql-init] Fix init meta table bug: varchar -> scale:0

### DIFF
--- a/java/dingo-mysql-init/src/main/java/io/dingodb/mysql/MysqlInit.java
+++ b/java/dingo-mysql-init/src/main/java/io/dingodb/mysql/MysqlInit.java
@@ -269,7 +269,7 @@ public class MysqlInit {
                     map.put(column.getName(), new Timestamp(System.currentTimeMillis()));
                     break;
                 default:
-                    map.put(column.getName(), "N");
+                    map.put(column.getName(), "Y");
 
             }
         });

--- a/java/dingo-mysql-init/src/main/resources/table-information-global_variables.json
+++ b/java/dingo-mysql-init/src/main/resources/table-information-global_variables.json
@@ -2,14 +2,14 @@
     {
       "name": "VARIABLE_NAME",
       "type": "varchar",
-      "scale": 64,
+      "scale": -2147483648,
       "primary": 0,
       "nullable": false
     },
     {
       "name": "VARIABLE_VALUE",
       "type": "varchar",
-      "scale": 1024,
+      "scale": -2147483648,
       "primary": -1,
       "nullable": true
     }

--- a/java/dingo-mysql-init/src/main/resources/table-mysql-db.json
+++ b/java/dingo-mysql-init/src/main/resources/table-mysql-db.json
@@ -2,173 +2,173 @@
     {
       "name": "Host",
       "type": "varchar",
-      "scale": 60,
+      "scale": -2147483648,
       "primary": 0,
       "nullable": false
     },
     {
       "name": "User",
       "type": "varchar",
-      "scale": 32,
+      "scale": -2147483648,
       "primary": 1,
       "nullable": false
     },
     {
       "name": "Db",
       "type": "varchar",
-      "scale": 64,
+      "scale": -2147483648,
       "primary": 2,
       "nullable": false
     },
     {
       "name": "Select_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Insert_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Update_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Delete_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Create_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Drop_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Grant_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "References_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Index_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Alter_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Create_tmp_table_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Lock_tables_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Create_view_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Show_view_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Create_routine_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Alter_routine_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Execute_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Event_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Trigger_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     }

--- a/java/dingo-mysql-init/src/main/resources/table-mysql-tables_priv.json
+++ b/java/dingo-mysql-init/src/main/resources/table-mysql-tables_priv.json
@@ -2,43 +2,43 @@
     {
       "name": "Host",
       "type": "varchar",
-      "scale": 60,
+      "scale": -2147483648,
       "primary": 0,
       "nullable": false
     },
     {
       "name": "User",
       "type": "varchar",
-      "scale": 32,
+      "scale": -2147483648,
       "primary": 1,
       "nullable": false
     },
     {
       "name": "Db",
       "type": "varchar",
-      "scale": 64,
+      "scale": -2147483648,
       "primary": 2,
       "nullable": false
     },
     {
       "name": "Table_name",
       "type": "varchar",
-      "scale": 64,
+      "scale": -2147483648,
       "primary": 3,
       "nullable": false
     },
     {
       "name": "Grantor",
       "type": "varchar",
-      "scale": 93,
       "default": "",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Timestamp",
       "type": "timestamp",
-      "scale": 0,
+      "scale": -2147483648,
       "default": "",
       "primary": -1,
       "nullable": false
@@ -46,7 +46,7 @@
     {
       "name": "Table_priv",
       "type": "varchar",
-      "scale": 1024,
+      "scale": -2147483648,
       "default": "",
       "primary": -1,
       "nullable": true
@@ -54,8 +54,8 @@
     {
       "name": "Column_priv",
       "type": "varchar",
-      "scale": 1024,
       "default": "",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": true
     }

--- a/java/dingo-mysql-init/src/main/resources/table-mysql-user.json
+++ b/java/dingo-mysql-init/src/main/resources/table-mysql-user.json
@@ -2,348 +2,349 @@
     {
       "name": "Host",
       "type": "varchar",
-      "scale": 60,
+      "scale": -2147483648,
       "primary": 0,
       "nullable": false
     },
     {
       "name": "User",
       "type": "varchar",
-      "scale": 32,
+      "scale": -2147483648,
       "primary": 1,
       "nullable": false
     },
     {
       "name": "Select_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Insert_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Update_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Delete_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Create_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Drop_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Reload_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Shutdown_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Process_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "File_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Grant_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "References_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Index_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Alter_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Show_db_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Super_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Create_tmp_table_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Lock_tables_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Execute_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Repl_slave_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Repl_client_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Create_view_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Show_view_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Create_routine_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Alter_routine_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Create_user_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Event_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Trigger_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "Create_tablespace_priv",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "ssl_type",
       "type": "varchar",
-      "scale": 32,
       "default": "",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": true
     },
     {
       "name": "ssl_cipher",
       "type": "varchar",
-      "scale": 65535,
       "default": "",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": true
     },
     {
       "name": "x509_issuer",
       "type": "varchar",
-      "scale": 65535,
       "default": "",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": true
     },
     {
       "name": "x509_subject",
       "type": "varchar",
-      "scale": 65535,
       "default": "",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": true
     },
     {
       "name": "max_questions",
       "type": "integer",
-      "scale": 11,
       "default": 0,
+      "precision": -1,
       "primary": -1,
       "nullable": true
     },
     {
       "name": "max_updates",
       "type": "integer",
-      "scale": 11,
       "default": 0,
+      "precision": -1,
       "primary": -1,
       "nullable": true
     },
     {
       "name": "max_connections",
       "type": "integer",
-      "scale": 11,
       "default": 0,
+      "precision": -1,
       "primary": -1,
       "nullable": true
     },
     {
       "name": "max_user_connections",
       "type": "integer",
-      "scale": 11,
       "default": 0,
+      "precision": -1,
       "primary": -1,
       "nullable": true
     },
     {
       "name": "plugin",
       "type": "varchar",
-      "scale": 64,
       "default": "'mysql_native_password'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "authentication_string",
       "type": "varchar",
-      "scale": 65535,
       "default": "",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": true
     },
     {
       "name": "password_expired",
       "type": "varchar",
-      "scale": 2,
       "default": "'N'",
+      "scale": -2147483648,
       "primary": -1,
       "nullable": false
     },
     {
       "name": "password_last_changed",
       "type": "timestamp",
-      "scale": 0,
+      "scale": -2147483648,
       "primary": -1,
       "nullable": true
     },
     {
       "name": "password_lifetime",
       "type": "integer",
-      "scale": 5,
+      "scale": -2147483648,
+      "precision": -1,
       "default": 0,
       "primary": -1,
       "nullable": true
@@ -351,7 +352,7 @@
     {
       "name": "account_locked",
       "type": "varchar",
-      "scale": 2,
+      "scale": -2147483648,
       "default": "'N'",
       "primary": -1,
       "nullable": false


### PR DESCRIPTION
1. 初始化元数据表时，varchar类型的scale不能为0，因为calcite验证会出错