### PR TITLE
[refactor][coordinator] Refactor coordinator client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,9 @@ add_executable(dingodb_client_coordinator
                src/client/coordinator_client.cc
                src/client/coordinator_client_function_coor.cc
                src/client/coordinator_client_function_meta.cc
-               src/client/coordinator_client_function_auto_increment.cc
+               src/client/coordinator_client_function_incr.cc
                src/common/helper.cc
+               src/coordinator/coordinator_interaction.cc
                ${VERSION_SRCS} $<TARGET_OBJECTS:PROTO_OBJS>)
 
 add_dependencies(DINGODB_OBJS ${DEPEND_LIBS})

--- a/proto/coordinator.proto
+++ b/proto/coordinator.proto
@@ -289,10 +289,11 @@ message GetCoordinatorMapRequest {
 }
 
 message GetCoordinatorMapResponse {
-  uint64 epoch = 1;
-  dingodb.pb.common.Location leader_location = 2;
-  repeated dingodb.pb.common.Location coordinator_locations = 3;
-  dingodb.pb.common.Location auto_increment_leader_location = 4;
+  dingodb.pb.error.Error error = 1;
+  uint64 epoch = 2;
+  dingodb.pb.common.Location leader_location = 3;
+  repeated dingodb.pb.common.Location coordinator_locations = 4;
+  dingodb.pb.common.Location auto_increment_leader_location = 5;
 }
 
 message DeleteStoreRequest {

--- a/proto/coordinator.proto
+++ b/proto/coordinator.proto
@@ -219,7 +219,16 @@ message CoordinatorMemoryInfo {
   uint64 table_metrics_map_count = 26;
   uint64 table_metrics_map_size = 27;
 
-  repeated dingodb.pb.common.KeyValue id_epoch_values = 28;
+  uint64 store_operation_map_count = 28;
+  uint64 store_operation_map_size = 29;
+
+  uint64 executor_user_map_count = 30;
+  uint64 executor_user_map_size = 31;
+
+  uint64 task_list_map_count = 32;
+  uint64 task_list_map_size = 33;
+
+  repeated dingodb.pb.common.KeyValue id_epoch_values = 40;
 }
 
 message HelloRequest {

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -310,6 +310,18 @@ message DropTableResponse {
   dingodb.pb.error.Error error = 1;
 }
 
+message TableIncrement {
+  uint64 table_id = 1;
+  uint64 start_id = 2;
+}
+
+message GetAutoIncrementsRequest {}
+
+message GetAutoIncrementsResponse {
+  dingodb.pb.error.Error error = 1;
+  repeated TableIncrement table_increments = 2;
+}
+
 message GetAutoIncrementRequest {
   DingoCommonId table_id = 1;
 }
@@ -425,6 +437,10 @@ service MetaService {
   // in: parent_schema_id schema_name
   // out: Schema
   rpc DropSchema(DropSchemaRequest) returns (DropSchemaResponse);
+
+  // GetAutoIncrements
+  // out: list of table_id, start_id
+  rpc GetAutoIncrements(GetAutoIncrementsRequest) returns (GetAutoIncrementsResponse);
 
   // GetAutoIncrement
   // in: table_id

--- a/src/client/coordinator_client.cc
+++ b/src/client/coordinator_client.cc
@@ -244,9 +244,11 @@ void* Sender(void* /*arg*/) {
   } else if (FLAGS_method == "GetTablesCount") {
     SendGetTablesCount(coordinator_interaction_meta);
   } else if (FLAGS_method == "CreateTable") {
-    SendCreateTable(coordinator_interaction_meta, false);
+    SendCreateTable(coordinator_interaction_meta, false, false);
   } else if (FLAGS_method == "CreateTableWithId") {
-    SendCreateTable(coordinator_interaction_meta, true);
+    SendCreateTable(coordinator_interaction_meta, true, false);
+  } else if (FLAGS_method == "CreateTableWithIncrement") {
+    SendCreateTable(coordinator_interaction_meta, false, true);
   } else if (FLAGS_method == "CreateTableId") {
     SendCreateTableId(coordinator_interaction_meta);
   } else if (FLAGS_method == "DropTable") {

--- a/src/client/coordinator_client.cc
+++ b/src/client/coordinator_client.cc
@@ -66,7 +66,7 @@ DEFINE_int64(index, 0, "index");
 DEFINE_uint32(service_type, 0, "service type for getting leader, 0: meta or coordinator, 2: auto increment");
 DEFINE_string(start_key, "", "start_key");
 DEFINE_string(end_key, "", "end_key");
-DEFINE_string(coordinator_url, "", "coordinator url");
+DEFINE_string(coor_url, "", "coordinator url");
 DEFINE_string(url, "", "coordinator url");
 
 std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction;
@@ -292,28 +292,26 @@ int main(int argc, char* argv[]) {
   }
 
   if (!FLAGS_url.empty()) {
-    FLAGS_coordinator_url = FLAGS_url;
+    FLAGS_coor_url = FLAGS_url;
   }
 
-  if (FLAGS_coordinator_url.empty()) {
+  if (FLAGS_coor_url.empty()) {
     DINGO_LOG(ERROR) << "coordinator url is empty, try to use file://./coor_list";
-    FLAGS_coordinator_url = "file://./coor_list";
+    FLAGS_coor_url = "file://./coor_list";
   }
 
-  if (!FLAGS_coordinator_url.empty()) {
+  if (!FLAGS_coor_url.empty()) {
     coordinator_interaction = std::make_shared<dingodb::CoordinatorInteraction>();
     if (!coordinator_interaction->InitByNameService(
-            FLAGS_coordinator_url, dingodb::pb::common::CoordinatorServiceType::ServiceTypeCoordinator)) {
-      DINGO_LOG(ERROR) << "Fail to init coordinator_interaction, please check parameter --url="
-                       << FLAGS_coordinator_url;
+            FLAGS_coor_url, dingodb::pb::common::CoordinatorServiceType::ServiceTypeCoordinator)) {
+      DINGO_LOG(ERROR) << "Fail to init coordinator_interaction, please check parameter --url=" << FLAGS_coor_url;
       return -1;
     }
 
     coordinator_interaction_meta = std::make_shared<dingodb::CoordinatorInteraction>();
     if (!coordinator_interaction_meta->InitByNameService(
-            FLAGS_coordinator_url, dingodb::pb::common::CoordinatorServiceType::ServiceTypeMeta)) {
-      DINGO_LOG(ERROR) << "Fail to init coordinator_interaction_meta, please check parameter --url="
-                       << FLAGS_coordinator_url;
+            FLAGS_coor_url, dingodb::pb::common::CoordinatorServiceType::ServiceTypeMeta)) {
+      DINGO_LOG(ERROR) << "Fail to init coordinator_interaction_meta, please check parameter --url=" << FLAGS_coor_url;
       return -1;
     }
   }

--- a/src/client/coordinator_client.cc
+++ b/src/client/coordinator_client.cc
@@ -68,6 +68,7 @@ DEFINE_string(start_key, "", "start_key");
 DEFINE_string(end_key, "", "end_key");
 DEFINE_string(coor_url, "", "coordinator url");
 DEFINE_string(url, "", "coordinator url");
+DEFINE_int64(schema_id, 0, "schema_id");
 
 std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction;
 std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction_meta;

--- a/src/client/coordinator_client.cc
+++ b/src/client/coordinator_client.cc
@@ -263,7 +263,9 @@ void* Sender(void* /*arg*/) {
     SendGetTableRange(coordinator_interaction_meta);
   } else if (FLAGS_method == "GetTableMetrics") {
     SendGetTableMetrics(coordinator_interaction_meta);
-  } else if (FLAGS_method == "GetAutoIncrement") {  // auto increment
+  } else if (FLAGS_method == "GetAutoIncrements") {  // auto increment
+    SendGetAutoIncrements(coordinator_interaction_meta);
+  } else if (FLAGS_method == "GetAutoIncrement") {
     SendGetAutoIncrement(coordinator_interaction_meta);
   } else if (FLAGS_method == "CreateAutoIncrement") {
     SendCreateAutoIncrement(coordinator_interaction_meta);

--- a/src/client/coordinator_client_function.h
+++ b/src/client/coordinator_client_function.h
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef DINGODB_COORDINATOR_CLIENT_FUNCTION_H_
+#define DINGODB_COORDINATOR_CLIENT_FUNCTION_H_
+
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <memory>
 #include <string>
 
 #include "braft/raft.h"
@@ -23,89 +27,88 @@
 #include "brpc/channel.h"
 #include "brpc/controller.h"
 #include "bthread/bthread.h"
+#include "coordinator/coordinator_interaction.h"
 #include "gflags/gflags.h"
 #include "google/protobuf/util/json_util.h"
 #include "proto/coordinator.pb.h"
 #include "proto/meta.pb.h"
 #include "proto/node.pb.h"
 
-std::string MessageToJsonString(const google::protobuf::Message& message);
-
-// common functions
-std::string GetLeaderLocation(uint32_t service_type);
-
-// coordinator service functions
-void SendGetNodeInfo(brpc::Controller& cntl, dingodb::pb::node::NodeService_Stub& stub);
-void SendGetLogLevel(brpc::Controller& cntl, dingodb::pb::node::NodeService_Stub& stub);
-void SendChangeLogLevel(brpc::Controller& cntl, dingodb::pb::node::NodeService_Stub& stub);
-void SendHello(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendGetStoreMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendGetExecutorMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendGetCoordinatorMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendGetRegionMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendCreateStore(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendDeleteStore(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendStoreHearbeat(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub,
-                       uint64_t store_id);
-void SendGetStoreMetrics(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendCreateExecutor(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendDeleteExecutor(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendCreateExecutorUser(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendUpdateExecutorUser(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendDeleteExecutorUser(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendGetExecutorUserMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendExecutorHeartbeat(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-
-// region
-void SendQueryRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendCreateRegionForSplit(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendDropRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendDropRegionPermanently(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendSplitRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendMergeRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendAddPeerRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendRemovePeerRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendGetOrphanRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-
-// store operation
-void SendGetStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendCleanStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendAddStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendRemoveStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-
-// task list
-void SendGetTaskList(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendCleanTaskList(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-
-// meta service functions
-void SendGetSchemas(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendGetSchema(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendGetSchemaByName(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendGetTablesCount(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendGetTables(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendGetTable(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendGetTableByName(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendGetTableRange(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendCreateTableId(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendCreateTable(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub, bool with_table_id);
-void SendCreateTableOld(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub, bool with_table_id);
-void SendDropTable(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendDropSchema(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendCreateSchema(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendGetTableMetrics(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
+// node service functions
+void SendGetNodeInfo();
+void SendGetLogLevel();
+void SendChangeLogLevel();
 
 // raft_control functions
-void SendRaftAddPeer(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
-void SendRaftRemovePeer(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub);
+void SendRaftAddPeer();
+void SendRaftRemovePeer();
+
+// coordinator service functions
+void SendHello(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetStoreMap(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetExecutorMap(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetCoordinatorMap(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetRegionMap(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendCreateStore(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendDeleteStore(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendStoreHearbeat(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction, uint64_t store_id);
+void SendGetStoreMetrics(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendCreateExecutor(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendDeleteExecutor(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendCreateExecutorUser(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendUpdateExecutorUser(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendDeleteExecutorUser(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetExecutorUserMap(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendExecutorHeartbeat(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+
+// region
+void SendQueryRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendCreateRegionForSplit(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendDropRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendDropRegionPermanently(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendSplitRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendMergeRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendAddPeerRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendRemovePeerRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetOrphanRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+
+// store operation
+void SendGetStoreOperation(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendCleanStoreOperation(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendAddStoreOperation(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendRemoveStoreOperation(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+
+// task list
+void SendGetTaskList(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendCleanTaskList(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+
+// meta service functions
+void SendGetSchemas(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetSchema(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetSchemaByName(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetTablesCount(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetTables(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetTable(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetTableByName(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetTableRange(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendCreateTableId(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendCreateTable(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction, bool with_table_id);
+void SendDropTable(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendDropSchema(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendCreateSchema(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGetTableMetrics(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
 
 // auto increment functions
-void SendGetAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendCreateAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendUpdateAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendGenerateAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
-void SendDeleteAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub);
+void SendGetAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendCreateAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendUpdateAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendGenerateAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
+void SendDeleteAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
 
 // debug
 void SendDebug();
 std::string EncodeUint64(uint64_t value);
 uint64_t DecodeUint64(const std::string& str);
+bool GetBrpcChannel(const std::string& location, brpc::Channel& channel);
+
+#endif  // DINGODB_COORDINATOR_CLIENT_FUNCTION_H_

--- a/src/client/coordinator_client_function.h
+++ b/src/client/coordinator_client_function.h
@@ -92,7 +92,8 @@ void SendGetTable(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_i
 void SendGetTableByName(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
 void SendGetTableRange(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
 void SendCreateTableId(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
-void SendCreateTable(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction, bool with_table_id);
+void SendCreateTable(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction, bool with_table_id,
+                     bool with_increment);
 void SendDropTable(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
 void SendDropSchema(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
 void SendCreateSchema(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);

--- a/src/client/coordinator_client_function.h
+++ b/src/client/coordinator_client_function.h
@@ -99,6 +99,7 @@ void SendCreateSchema(std::shared_ptr<dingodb::CoordinatorInteraction> coordinat
 void SendGetTableMetrics(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
 
 // auto increment functions
+void SendGetAutoIncrements(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
 void SendGetAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
 void SendCreateAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);
 void SendUpdateAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction);

--- a/src/client/coordinator_client_function_coor.cc
+++ b/src/client/coordinator_client_function_coor.cc
@@ -753,7 +753,21 @@ void SendSplitRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinato
     DINGO_LOG(INFO) << " half_diff = " << dingodb::Helper::StringToHex(half_diff);
     DINGO_LOG(INFO) << " mid       = " << dingodb::Helper::StringToHex(mid);
 
-    request.mutable_split_request()->set_split_watershed_key(mid.substr(1, mid.size() - 1));
+    auto real_mid = mid.substr(1, mid.size() - 1);
+    DINGO_LOG(INFO) << " mid real  = " << dingodb::Helper::StringToHex(real_mid);
+
+    request.mutable_split_request()->set_split_watershed_key(real_mid);
+
+    if (query_response.region().definition().range().start_key().compare(real_mid) >= 0 ||
+        query_response.region().definition().range().end_key().compare(real_mid) <= 0) {
+      DINGO_LOG(ERROR) << "SplitRegion split_watershed_key is illegal, split_watershed_key = "
+                       << dingodb::Helper::StringToHex(real_mid)
+                       << ", query_response.region()_id = " << query_response.region().id() << " start_key="
+                       << dingodb::Helper::StringToHex(query_response.region().definition().range().start_key())
+                       << ", end_key="
+                       << dingodb::Helper::StringToHex(query_response.region().definition().range().end_key());
+      return;
+    }
   }
 
   DINGO_LOG(INFO) << "split from region " << FLAGS_split_from_id << " to region " << FLAGS_split_to_id

--- a/src/client/coordinator_client_function_coor.cc
+++ b/src/client/coordinator_client_function_coor.cc
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "client/coordinator_client_function.h"
 #include "common/helper.h"
 #include "common/logging.h"
+#include "coordinator/coordinator_interaction.h"
 #include "gflags/gflags_declare.h"
 #include "proto/common.pb.h"
 #include "proto/coordinator.pb.h"
@@ -49,67 +51,128 @@ DECLARE_int64(region_cmd_id);
 DECLARE_string(store_ids);
 DECLARE_int64(index);
 
-std::string MessageToJsonString(const google::protobuf::Message& message) {
-  std::string json_string;
-  google::protobuf::util::JsonOptions options;
-  options.always_print_primitive_fields = true;
-  google::protobuf::util::Status status = google::protobuf::util::MessageToJsonString(message, &json_string, options);
-  if (!status.ok()) {
-    std::cerr << "Failed to convert message to JSON: [" << status.message() << "]" << std::endl;
-  }
-  return json_string;
-}
+// raft control
+void SendRaftAddPeer() {
+  dingodb::pb::coordinator::RaftControlRequest request;
+  dingodb::pb::coordinator::RaftControlResponse response;
 
-std::string GetLeaderLocation(uint32_t service_type) {
-  braft::PeerId leader;
-  if (!FLAGS_coordinator_addr.empty()) {
-    if (leader.parse(FLAGS_coordinator_addr) != 0) {
-      DINGO_LOG(ERROR) << "Fail to parse peer_id " << FLAGS_coordinator_addr;
-      return std::string();
-    }
+  if (!FLAGS_host.empty() && FLAGS_port != 0) {
+    request.set_add_peer(FLAGS_host + ":" + std::to_string(FLAGS_port));
   } else {
-    DINGO_LOG(ERROR) << "Please set --coordinator_addr";
-    return std::string();
+    DINGO_LOG(ERROR) << "host or port is empty";
+    return;
   }
+  request.set_op_type(::dingodb::pb::coordinator::RaftControlOp::AddPeer);
 
-  // rpc
-  brpc::Channel channel;
-  if (channel.Init(leader.addr, nullptr) != 0) {
-    DINGO_LOG(ERROR) << "Fail to init channel to " << leader;
-    bthread_usleep(FLAGS_timeout_ms * 1000L);
-    return std::string();
+  if (FLAGS_index == 0) {
+    request.set_node_index(dingodb::pb::coordinator::RaftControlNodeIndex::CoordinatorNodeIndex);
+  } else if (FLAGS_index == 1) {
+    request.set_node_index(dingodb::pb::coordinator::RaftControlNodeIndex::AutoIncrementNodeIndex);
+  } else {
+    DINGO_LOG(ERROR) << "index is error";
+    return;
   }
-  dingodb::pb::coordinator::CoordinatorService_Stub stub(&channel);
-  dingodb::pb::coordinator::GetCoordinatorMapRequest request;
-  dingodb::pb::coordinator::GetCoordinatorMapResponse response;
-
-  request.set_cluster_id(0);
 
   brpc::Controller cntl;
-  stub.GetCoordinatorMap(&cntl, &request, &response, nullptr);
+  cntl.set_timeout_ms(FLAGS_timeout_ms);
+
+  if (FLAGS_coordinator_addr.empty()) {
+    DINGO_LOG(ERROR) << "Please set --addr or --coordinator_addr";
+    return;
+  }
+
+  brpc::Channel channel;
+  if (!GetBrpcChannel(FLAGS_coordinator_addr, channel)) {
+    return;
+  }
+  dingodb::pb::coordinator::CoordinatorService_Stub stub(&channel);
+
+  stub.RaftControl(&cntl, &request, &response, nullptr);
   if (cntl.Failed()) {
     DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    return std::string();
+    // bthread_usleep(FLAGS_timeout_ms * 1000L);
   }
 
-  auto leader_location = response.leader_location().host() + ":" + std::to_string(response.leader_location().port());
-  DINGO_LOG(INFO) << "leader_location: " << leader_location;
-  auto auto_increment_leader_location = response.auto_increment_leader_location().host() + ":" +
-                                        std::to_string(response.auto_increment_leader_location().port());
-  DINGO_LOG(INFO) << " auto_increment_leader_location: " << auto_increment_leader_location;
-  if (service_type == dingodb::pb::common::CoordinatorServiceType::ServiceTypeAutoIncrement) {
-    return auto_increment_leader_location;
+  if (FLAGS_log_each_request) {
+    DINGO_LOG(INFO) << "Received response"
+                    << " request_attachment=" << cntl.request_attachment().size()
+                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
+    DINGO_LOG_INFO << response.DebugString();
   }
-  return leader_location;
 }
 
-void SendGetNodeInfo(brpc::Controller& cntl, dingodb::pb::node::NodeService_Stub& stub) {
+void SendRaftRemovePeer() {
+  dingodb::pb::coordinator::RaftControlRequest request;
+  dingodb::pb::coordinator::RaftControlResponse response;
+
+  if (!FLAGS_host.empty() && FLAGS_port != 0) {
+    request.set_remove_peer(FLAGS_host + ":" + std::to_string(FLAGS_port));
+  } else {
+    DINGO_LOG(ERROR) << "host or port is empty";
+    return;
+  }
+  request.set_op_type(::dingodb::pb::coordinator::RaftControlOp::RemovePeer);
+
+  if (FLAGS_index == 0) {
+    request.set_node_index(dingodb::pb::coordinator::RaftControlNodeIndex::CoordinatorNodeIndex);
+  } else if (FLAGS_index == 1) {
+    request.set_node_index(dingodb::pb::coordinator::RaftControlNodeIndex::AutoIncrementNodeIndex);
+  } else {
+    DINGO_LOG(ERROR) << "index is error";
+    return;
+  }
+
+  brpc::Controller cntl;
+  cntl.set_timeout_ms(FLAGS_timeout_ms);
+
+  if (FLAGS_coordinator_addr.empty()) {
+    DINGO_LOG(ERROR) << "Please set --addr or --coordinator_addr";
+    return;
+  }
+
+  brpc::Channel channel;
+  if (!GetBrpcChannel(FLAGS_coordinator_addr, channel)) {
+    return;
+  }
+  dingodb::pb::coordinator::CoordinatorService_Stub stub(&channel);
+
+  stub.RaftControl(&cntl, &request, &response, nullptr);
+  if (cntl.Failed()) {
+    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
+    // bthread_usleep(FLAGS_timeout_ms * 1000L);
+  }
+
+  if (FLAGS_log_each_request) {
+    DINGO_LOG(INFO) << "Received response"
+                    << " request_attachment=" << cntl.request_attachment().size()
+                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
+    DINGO_LOG_INFO << response.DebugString();
+  }
+}
+
+// node service
+void SendGetNodeInfo() {
   dingodb::pb::node::GetNodeInfoRequest request;
   dingodb::pb::node::GetNodeInfoResponse response;
 
   std::string const key = "Hello";
   // const char* op = nullptr;
   request.set_cluster_id(0);
+
+  brpc::Controller cntl;
+  cntl.set_timeout_ms(FLAGS_timeout_ms);
+
+  if (FLAGS_coordinator_addr.empty()) {
+    DINGO_LOG(ERROR) << "Please set --addr or --coordinator_addr";
+    return;
+  }
+
+  brpc::Channel channel;
+  if (!GetBrpcChannel(FLAGS_coordinator_addr, channel)) {
+    return;
+  }
+  dingodb::pb::node::NodeService_Stub stub(&channel);
+
   stub.GetNodeInfo(&cntl, &request, &response, nullptr);
   if (cntl.Failed()) {
     DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
@@ -125,24 +188,34 @@ void SendGetNodeInfo(brpc::Controller& cntl, dingodb::pb::node::NodeService_Stub
   }
 }
 
-void SendGetLogLevel(brpc::Controller& cntl, dingodb::pb::node::NodeService_Stub& stub) {
+void SendGetLogLevel() {
   dingodb::pb::node::GetLogLevelRequest request;
   dingodb::pb::node::GetLogLevelResponse response;
+
+  brpc::Controller cntl;
+  cntl.set_timeout_ms(FLAGS_timeout_ms);
+
+  if (FLAGS_coordinator_addr.empty()) {
+    DINGO_LOG(ERROR) << "Please set --addr or --coordinator_addr";
+    return;
+  }
+
+  brpc::Channel channel;
+  if (!GetBrpcChannel(FLAGS_coordinator_addr, channel)) {
+    return;
+  }
+  dingodb::pb::node::NodeService_Stub stub(&channel);
+
   stub.GetLogLevel(&cntl, &request, &response, nullptr);
   if (cntl.Failed()) {
     DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
   }
 
-  if (FLAGS_log_each_request) {
-    std::string format_response = MessageToJsonString(response);
-    DINGO_LOG(INFO) << "Received response" << format_response
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  DINGO_LOG(INFO) << response.DebugString();
+  DINGO_LOG(INFO) << ::dingodb::pb::node::LogLevel_descriptor()->FindValueByNumber(response.log_level())->name();
 }
 
-void SendChangeLogLevel(brpc::Controller& cntl, dingodb::pb::node::NodeService_Stub& stub) {
+void SendChangeLogLevel() {
   dingodb::pb::node::ChangeLogLevelRequest request;
   dingodb::pb::node::ChangeLogLevelResponse response;
 
@@ -159,8 +232,8 @@ void SendChangeLogLevel(brpc::Controller& cntl, dingodb::pb::node::NodeService_S
   } else if (FLAGS_level == "FATAL") {
     request.set_log_level(dingodb::pb::node::FATAL);
   } else {
-    DINGO_LOG(WARNING) << "level is not valid";
-    request.set_log_level(dingodb::pb::node::WARNING);
+    DINGO_LOG(WARNING) << "level is not valid, please set --level=DEBUG|INFO|WARNING|ERROR|FATAL";
+    return;
   }
 
   auto* log_detail = request.mutable_log_detail();
@@ -168,18 +241,32 @@ void SendChangeLogLevel(brpc::Controller& cntl, dingodb::pb::node::NodeService_S
   log_detail->set_max_log_size(100);
   log_detail->set_stop_logging_if_full_disk(false);
 
+  brpc::Controller cntl;
+  cntl.set_timeout_ms(FLAGS_timeout_ms);
+
+  if (FLAGS_coordinator_addr.empty()) {
+    DINGO_LOG(ERROR) << "Please set --addr or --coordinator_addr";
+    return;
+  }
+
+  brpc::Channel channel;
+  if (!GetBrpcChannel(FLAGS_coordinator_addr, channel)) {
+    return;
+  }
+  dingodb::pb::node::NodeService_Stub stub(&channel);
+
   stub.ChangeLogLevel(&cntl, &request, &response, nullptr);
   if (cntl.Failed()) {
     DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
   }
 
-  std::string const request_format = MessageToJsonString(request);
-  std::string const response_format = MessageToJsonString(response);
-  DINGO_LOG(INFO) << request_format;
-  DINGO_LOG(INFO) << response_format;
+  DINGO_LOG(INFO) << request.DebugString();
+  DINGO_LOG(INFO) << ::dingodb::pb::node::LogLevel_descriptor()->FindValueByNumber(request.log_level())->name();
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendHello(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+// coordinator service
+void SendHello(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::HelloRequest request;
   dingodb::pb::coordinator::HelloResponse response;
 
@@ -187,31 +274,22 @@ void SendHello(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorServ
   // const char* op = nullptr;
   request.set_hello(0);
   request.set_get_memory_info(true);
-  stub.Hello(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
 
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " hello=" << request.hello() << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("Hello", request, response);
+  DINGO_LOG(INFO) << "SendRequest status: " << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendGetStoreMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendGetStoreMap(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::GetStoreMapRequest request;
   dingodb::pb::coordinator::GetStoreMapResponse response;
 
   request.set_epoch(1);
 
-  stub.GetStoreMap(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
+  auto status = coordinator_interaction->SendRequest("GetStoreMap", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+
+  DINGO_LOG(INFO) << response.DebugString();
 
   // print all store's id, state, in_state, create_timestamp, last_seen_timestamp
   for (auto const& store : response.storemap().stores()) {
@@ -219,112 +297,63 @@ void SendGetStoreMap(brpc::Controller& cntl, dingodb::pb::coordinator::Coordinat
                     << " create_timestamp=" << store.create_timestamp()
                     << " last_seen_timestamp=" << store.last_seen_timestamp();
   }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " get_store_map=" << request.epoch()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
 }
 
-void SendGetExecutorMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendGetExecutorMap(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::GetExecutorMapRequest request;
   dingodb::pb::coordinator::GetExecutorMapResponse response;
 
   request.set_epoch(1);
 
-  stub.GetExecutorMap(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " get_executor_map=" << request.epoch()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("GetExecutorMap", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendGetCoordinatorMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendGetCoordinatorMap(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::GetCoordinatorMapRequest request;
   dingodb::pb::coordinator::GetCoordinatorMapResponse response;
 
   request.set_cluster_id(0);
 
-  stub.GetCoordinatorMap(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " get_coordinator_map=" << request.cluster_id()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("GetCoordinatorMap", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendGetRegionMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendGetRegionMap(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::GetRegionMapRequest request;
   dingodb::pb::coordinator::GetRegionMapResponse response;
 
   request.set_epoch(1);
 
-  stub.GetRegionMap(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
+  auto status = coordinator_interaction->SendRequest("GetRegionMap", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+
+  for (const auto& region : response.regionmap().regions()) {
+    DINGO_LOG(INFO) << region.DebugString();
   }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " get_store_map=" << request.epoch()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us()
-                    << " response=" << MessageToJsonString(response);
-    for (const auto& region : response.regionmap().regions()) {
-      DINGO_LOG(INFO) << region.DebugString();
-    }
-    for (const auto& region : response.regionmap().regions()) {
-      DINGO_LOG(INFO) << "Region id=" << region.id() << " name=" << region.definition().name()
-                      << " state=" << dingodb::pb::common::RegionState_Name(region.state())
-                      << " leader_store_id=" << region.leader_store_id()
-                      << " replica_state=" << dingodb::pb::common::ReplicaStatus_Name(region.replica_status())
-                      << " raft_status=" << dingodb::pb::common::RegionRaftStatus_Name(region.raft_status());
-    }
-
-    // DINGO_LOG(INFO) << response.DebugString();
+  for (const auto& region : response.regionmap().regions()) {
+    DINGO_LOG(INFO) << "Region id=" << region.id() << " name=" << region.definition().name()
+                    << " state=" << dingodb::pb::common::RegionState_Name(region.state())
+                    << " leader_store_id=" << region.leader_store_id()
+                    << " replica_state=" << dingodb::pb::common::ReplicaStatus_Name(region.replica_status())
+                    << " raft_status=" << dingodb::pb::common::RegionRaftStatus_Name(region.raft_status());
   }
 }
 
-void SendCreateStore(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendCreateStore(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::CreateStoreRequest request;
   dingodb::pb::coordinator::CreateStoreResponse response;
 
   request.set_cluster_id(1);
-  stub.CreateStore(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorCode() << "[" << cntl.ErrorText() << "]";
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
 
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " create store cluster_id =" << request.cluster_id()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("CreateStore", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendDeleteStore(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendDeleteStore(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::DeleteStoreRequest request;
   dingodb::pb::coordinator::DeleteStoreResponse response;
 
@@ -343,22 +372,12 @@ void SendDeleteStore(brpc::Controller& cntl, dingodb::pb::coordinator::Coordinat
   auto* keyring = request.mutable_keyring();
   keyring->assign(FLAGS_keyring);
 
-  stub.DeleteStore(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorCode() << "[" << cntl.ErrorText() << "]";
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " create store cluster_id =" << request.cluster_id()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("DeleteStore", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendCreateExecutor(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendCreateExecutor(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::CreateExecutorRequest request;
   dingodb::pb::coordinator::CreateExecutorResponse response;
 
@@ -387,22 +406,13 @@ void SendCreateExecutor(brpc::Controller& cntl, dingodb::pb::coordinator::Coordi
   request.mutable_executor()->mutable_server_location()->set_port(FLAGS_port);
 
   request.set_cluster_id(1);
-  stub.CreateExecutor(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorCode() << "[" << cntl.ErrorText() << "]";
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
 
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " create executor cluster_id =" << request.cluster_id()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("CreateExecutor", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendDeleteExecutor(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendDeleteExecutor(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::DeleteExecutorRequest request;
   dingodb::pb::coordinator::DeleteExecutorResponse response;
 
@@ -425,22 +435,12 @@ void SendDeleteExecutor(brpc::Controller& cntl, dingodb::pb::coordinator::Coordi
   }
   request.mutable_executor()->mutable_executor_user()->set_keyring(FLAGS_keyring);
 
-  stub.DeleteExecutor(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorCode() << "[" << cntl.ErrorText() << "]";
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " create executor cluster_id =" << request.cluster_id()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("DeleteExecutor", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendCreateExecutorUser(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendCreateExecutorUser(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::CreateExecutorUserRequest request;
   dingodb::pb::coordinator::CreateExecutorUserResponse response;
 
@@ -457,22 +457,13 @@ void SendCreateExecutorUser(brpc::Controller& cntl, dingodb::pb::coordinator::Co
   }
 
   request.set_cluster_id(1);
-  stub.CreateExecutorUser(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorCode() << "[" << cntl.ErrorText() << "]";
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
 
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " create executor user cluster_id =" << request.cluster_id()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("CreateExecutorUser", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendUpdateExecutorUser(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendUpdateExecutorUser(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::UpdateExecutorUserRequest request;
   dingodb::pb::coordinator::UpdateExecutorUserResponse response;
 
@@ -495,22 +486,13 @@ void SendUpdateExecutorUser(brpc::Controller& cntl, dingodb::pb::coordinator::Co
   request.mutable_executor_user_update()->set_keyring(FLAGS_new_keyring);
 
   request.set_cluster_id(1);
-  stub.UpdateExecutorUser(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorCode() << "[" << cntl.ErrorText() << "]";
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
 
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " update executor user cluster_id =" << request.cluster_id()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("UpdateExecutorUser", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendDeleteExecutorUser(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendDeleteExecutorUser(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::DeleteExecutorUserRequest request;
   dingodb::pb::coordinator::DeleteExecutorUserResponse response;
 
@@ -527,42 +509,24 @@ void SendDeleteExecutorUser(brpc::Controller& cntl, dingodb::pb::coordinator::Co
   request.mutable_executor_user()->set_keyring(FLAGS_keyring);
 
   request.set_cluster_id(1);
-  stub.DeleteExecutorUser(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorCode() << "[" << cntl.ErrorText() << "]";
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
 
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " delete executor user cluster_id =" << request.cluster_id()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("DeleteExecutorUser", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendGetExecutorUserMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendGetExecutorUserMap(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::GetExecutorUserMapRequest request;
   dingodb::pb::coordinator::GetExecutorUserMapResponse response;
 
   request.set_cluster_id(1);
-  stub.GetExecutorUserMap(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorCode() << "[" << cntl.ErrorText() << "]";
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
 
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " get executor user map cluster_id =" << request.cluster_id()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("GetExecutorUserMap", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendExecutorHeartbeat(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendExecutorHeartbeat(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::ExecutorHeartbeatRequest request;
   dingodb::pb::coordinator::ExecutorHeartbeatResponse response;
 
@@ -594,23 +558,12 @@ void SendExecutorHeartbeat(brpc::Controller& cntl, dingodb::pb::coordinator::Coo
     user->set_keyring(FLAGS_keyring);
   }
 
-  stub.ExecutorHeartbeat(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorCode() << "[" << cntl.ErrorText() << "]";
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " executor heartbeat executor_id=" << request.executor().id()
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("ExecutorHeartbeat", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendStoreHearbeat(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub,
-                       uint64_t store_id) {
+void SendStoreHearbeat(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction, uint64_t store_id) {
   dingodb::pb::coordinator::StoreHeartbeatRequest request;
   dingodb::pb::coordinator::StoreHeartbeatResponse response;
 
@@ -628,64 +581,12 @@ void SendStoreHearbeat(brpc::Controller& cntl, dingodb::pb::coordinator::Coordin
   raft_location->set_port(19192);
   store->set_resource_tag("DINGO_DEFAULT");
 
-  // mock regions
-  // for (int i = 0; i < 3; i++) {
-  //   auto* region = request.add_regions();
-  //   region->set_id(store_id * 100 + i);
-  //   region->set_epoch(1);
-  //   std::string region_name("test_region_");
-  //   region_name.append(std::to_string(i));
-  //   region->set_name(region_name);
-  //   region->set_state(::dingodb::pb::common::RegionState::REGION_NORMAL);
-  //   region->set_leader_store_id(1);
-
-  //   // mock peers
-  //   for (int j = 0; j < 3; j++) {
-  //     auto* peer = region->add_peers();
-  //     peer->set_store_id(store_id);
-  //     auto* server_location = peer->mutable_server_location();
-  //     server_location->set_host("127.0.0.1");
-  //     server_location->set_port(19191);
-  //     auto* raft_location = peer->mutable_server_location();
-  //     raft_location->set_host("127.0.0.1");
-  //     raft_location->set_port(19192);
-  //   }
-
-  //   // mock range
-  //   auto* range = region->mutable_range();
-  //   const char start_key[] = {0, 0, 0, 0};
-  //   const char end_key[] = {static_cast<char>(255), static_cast<char>(255), static_cast<char>(255),
-  //                           static_cast<char>(255)};
-
-  //   range->set_start_key(std::string(start_key));
-  //   range->set_end_key(std::string(end_key));
-
-  //   // mock meta
-  //   region->set_schema_id(::dingodb::pb::meta::ReservedSchemaIds::DINGO_SCHEMA);
-  //   region->set_table_id(2);
-
-  //   // mock create ts
-  //   region->set_create_timestamp(butil::gettimeofday_ms());
-  // }
-
-  // DINGO_LOG(INFO) << request.DebugString();
-
-  stub.StoreHeartbeat(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " store_heartbeat "
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("StoreHeartbeat", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendGetStoreMetrics(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendGetStoreMetrics(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::GetStoreMetricsRequest request;
   dingodb::pb::coordinator::GetStoreMetricsResponse response;
 
@@ -693,22 +594,13 @@ void SendGetStoreMetrics(brpc::Controller& cntl, dingodb::pb::coordinator::Coord
     request.set_store_id(std::stoull(FLAGS_id));
   }
 
-  stub.GetStoreMetrics(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("GetStoreMetrics", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
 // region
-void SendQueryRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendQueryRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::QueryRegionRequest request;
   dingodb::pb::coordinator::QueryRegionResponse response;
 
@@ -719,21 +611,12 @@ void SendQueryRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coordinat
     return;
   }
 
-  stub.QueryRegion(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("QueryRegion", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendCreateRegionForSplit(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendCreateRegionForSplit(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   if (FLAGS_id.empty()) {
     DINGO_LOG(ERROR) << "id is empty (this is the region id to split)";
     return;
@@ -745,12 +628,10 @@ void SendCreateRegionForSplit(brpc::Controller& cntl, dingodb::pb::coordinator::
   dingodb::pb::coordinator::QueryRegionResponse query_response;
 
   query_request.set_region_id(region_id_split);
-  stub.QueryRegion(&cntl, &query_request, &query_response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-    return;
-  }
+
+  auto status = coordinator_interaction->SendRequest("QueryRegion", query_request, query_response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << query_response.DebugString();
 
   if (query_response.region().definition().peers_size() == 0) {
     DINGO_LOG(ERROR) << "region not found";
@@ -784,22 +665,12 @@ void SendCreateRegionForSplit(brpc::Controller& cntl, dingodb::pb::coordinator::
 
   DINGO_LOG(INFO) << "Create region request: " << request.DebugString();
 
-  cntl.Reset();
-  stub.CreateRegion(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status2 = coordinator_interaction->SendRequest("CreateRegion", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status2;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendDropRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendDropRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::DropRegionRequest request;
   dingodb::pb::coordinator::DropRegionResponse response;
 
@@ -810,21 +681,12 @@ void SendDropRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coordinato
     return;
   }
 
-  stub.DropRegion(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG(INFO) << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("DropRegion", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendDropRegionPermanently(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendDropRegionPermanently(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::DropRegionPermanentlyRequest request;
   dingodb::pb::coordinator::DropRegionPermanentlyResponse response;
 
@@ -835,21 +697,12 @@ void SendDropRegionPermanently(brpc::Controller& cntl, dingodb::pb::coordinator:
     return;
   }
 
-  stub.DropRegionPermanently(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG_INFO << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("DropRegionPermanently", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendSplitRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendSplitRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::SplitRegionRequest request;
   dingodb::pb::coordinator::SplitRegionResponse response;
 
@@ -870,13 +723,10 @@ void SendSplitRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coordinat
     dingodb::pb::coordinator::QueryRegionRequest query_request;
     dingodb::pb::coordinator::QueryRegionResponse query_response;
     query_request.set_region_id(FLAGS_split_from_id);
-    cntl.Reset();
-    stub.QueryRegion(&cntl, &query_request, &query_response, nullptr);
-    if (cntl.Failed()) {
-      DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-      // bthread_usleep(FLAGS_timeout_ms * 1000L);
-      return;
-    }
+
+    auto status = coordinator_interaction->SendRequest("QueryRegion", query_request, query_response);
+    DINGO_LOG(INFO) << "SendRequest status=" << status;
+    DINGO_LOG(INFO) << query_response.DebugString();
 
     if (query_response.region().definition().range().start_key().empty()) {
       DINGO_LOG(ERROR) << "split from region " << FLAGS_split_from_id << " has no start_key";
@@ -910,12 +760,9 @@ void SendSplitRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coordinat
                   << " with watershed key ["
                   << dingodb::Helper::StringToHex(request.split_request().split_watershed_key()) << "] will be sent";
 
-  cntl.Reset();
-  stub.SplitRegion(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
+  auto status = coordinator_interaction->SendRequest("SplitRegion", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 
   if (response.has_error() && response.error().errcode() != dingodb::pb::error::Errno::OK) {
     DINGO_LOG(INFO) << "split from region " << FLAGS_split_from_id << " to region " << FLAGS_split_to_id
@@ -931,7 +778,7 @@ void SendSplitRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coordinat
   }
 }
 
-void SendMergeRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendMergeRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::MergeRegionRequest request;
   dingodb::pb::coordinator::MergeRegionResponse response;
 
@@ -949,21 +796,12 @@ void SendMergeRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coordinat
     return;
   }
 
-  stub.MergeRegion(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG_INFO << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("MergeRegion", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG(INFO) << response.DebugString();
 }
 
-void SendAddPeerRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendAddPeerRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   if (FLAGS_id.empty()) {
     DINGO_LOG(ERROR) << "id is empty (this is store_id)";
     return;
@@ -976,12 +814,9 @@ void SendAddPeerRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coordin
   dingodb::pb::coordinator::GetStoreMapResponse response;
 
   request.set_epoch(0);
-  stub.GetStoreMap(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-    return;
-  }
+
+  auto status = coordinator_interaction->SendRequest("GetStoreMap", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
 
   dingodb::pb::common::Peer new_peer;
   for (const auto& store : response.storemap().stores()) {
@@ -1003,13 +838,9 @@ void SendAddPeerRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coordin
   dingodb::pb::coordinator::QueryRegionResponse query_response;
 
   query_request.set_region_id(FLAGS_region_id);
-  cntl.Reset();
-  stub.QueryRegion(&cntl, &query_request, &query_response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-    return;
-  }
+
+  auto status2 = coordinator_interaction->SendRequest("QueryRegion", query_request, query_response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status2;
 
   if (query_response.region().definition().peers_size() == 0) {
     DINGO_LOG(ERROR) << "region not found";
@@ -1035,19 +866,9 @@ void SendAddPeerRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coordin
 
   DINGO_LOG(INFO) << "new_definition: " << new_definition->DebugString();
 
-  cntl.Reset();
-  stub.ChangePeerRegion(&cntl, &change_peer_request, &change_peer_response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG_INFO << change_peer_response.DebugString();
-  }
+  auto status3 = coordinator_interaction->SendRequest("ChangePeerRegion", change_peer_request, change_peer_response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status3;
+  DINGO_LOG(INFO) << change_peer_response.DebugString();
 
   if (change_peer_response.has_error() && change_peer_response.error().errcode() != dingodb::pb::error::Errno::OK) {
     DINGO_LOG(ERROR) << "change peer error: " << change_peer_response.error().DebugString();
@@ -1056,7 +877,7 @@ void SendAddPeerRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coordin
   }
 }
 
-void SendRemovePeerRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendRemovePeerRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   if (FLAGS_id.empty()) {
     DINGO_LOG(ERROR) << "id is empty (this is store_id)";
     return;
@@ -1069,12 +890,9 @@ void SendRemovePeerRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coor
   dingodb::pb::coordinator::QueryRegionResponse query_response;
 
   query_request.set_region_id(FLAGS_region_id);
-  stub.QueryRegion(&cntl, &query_request, &query_response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-    return;
-  }
+
+  auto status = coordinator_interaction->SendRequest("QueryRegion", query_request, query_response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
 
   if (query_response.region().definition().peers_size() == 0) {
     DINGO_LOG(ERROR) << "region not found";
@@ -1110,19 +928,10 @@ void SendRemovePeerRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coor
   }
 
   DINGO_LOG(INFO) << "new_definition: " << new_definition->DebugString();
-  cntl.Reset();
-  stub.ChangePeerRegion(&cntl, &change_peer_request, &change_peer_response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS
-  }
 
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG_INFO << change_peer_response.DebugString();
-  }
+  auto status2 = coordinator_interaction->SendRequest("ChangePeerRegion", change_peer_request, change_peer_response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status2;
+  DINGO_LOG(INFO) << change_peer_response.DebugString();
 
   if (change_peer_response.has_error() && change_peer_response.error().errcode() != dingodb::pb::error::Errno::OK) {
     DINGO_LOG(ERROR) << "change peer error: " << change_peer_response.error().DebugString();
@@ -1131,7 +940,7 @@ void SendRemovePeerRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coor
   }
 }
 
-void SendGetOrphanRegion(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendGetOrphanRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::GetOrphanRegionRequest request;
   dingodb::pb::coordinator::GetOrphanRegionResponse response;
 
@@ -1139,15 +948,9 @@ void SendGetOrphanRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coord
     request.set_store_id(std::stoull(FLAGS_id));
   }
 
-  stub.GetOrphanRegion(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
+  auto status = coordinator_interaction->SendRequest("GetOrphanRegion", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
 
-  DINGO_LOG(INFO) << "Received response"
-                  << " request_attachment=" << cntl.request_attachment().size()
-                  << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
   DINGO_LOG(INFO) << "orphan_regions_size=" << response.orphan_regions_size();
 
   for (const auto& it : response.orphan_regions()) {
@@ -1162,7 +965,7 @@ void SendGetOrphanRegion(brpc::Controller& cntl, dingodb::pb::coordinator::Coord
 }
 
 // store operation
-void SendGetStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendGetStoreOperation(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::GetStoreOperationRequest request;
   dingodb::pb::coordinator::GetStoreOperationResponse response;
 
@@ -1170,11 +973,8 @@ void SendGetStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::Coo
     request.set_store_id(std::stoull(FLAGS_id));
   }
 
-  stub.GetStoreOperation(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
+  auto status = coordinator_interaction->SendRequest("GetStoreOperation", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
 
   for (const auto& it : response.store_operations()) {
     DINGO_LOG(INFO) << "store_id=" << it.id() << " cmd_count=" << it.region_cmds_size();
@@ -1183,15 +983,9 @@ void SendGetStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::Coo
   for (const auto& it : response.store_operations()) {
     DINGO_LOG(INFO) << "store_id=" << it.id() << " store_operation=" << it.DebugString();
   }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-  }
 }
 
-void SendCleanStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendCleanStoreOperation(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::CleanStoreOperationRequest request;
   dingodb::pb::coordinator::CleanStoreOperationResponse response;
 
@@ -1202,21 +996,12 @@ void SendCleanStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::C
     return;
   }
 
-  stub.CleanStoreOperation(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG_INFO << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("CleanStoreOperation", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG_INFO << response.DebugString();
 }
 
-void SendAddStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendAddStoreOperation(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::AddStoreOperationRequest request;
   dingodb::pb::coordinator::AddStoreOperationResponse response;
 
@@ -1237,21 +1022,12 @@ void SendAddStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::Coo
     return;
   }
 
-  stub.AddStoreOperation(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG_INFO << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("AddStoreOperation", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG_INFO << response.DebugString();
 }
 
-void SendRemoveStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendRemoveStoreOperation(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::RemoveStoreOperationRequest request;
   dingodb::pb::coordinator::RemoveStoreOperationResponse response;
 
@@ -1269,109 +1045,21 @@ void SendRemoveStoreOperation(brpc::Controller& cntl, dingodb::pb::coordinator::
     return;
   }
 
-  stub.RemoveStoreOperation(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG_INFO << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("RemoveStoreOperation", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG_INFO << response.DebugString();
 }
 
-void SendRaftAddPeer(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
-  dingodb::pb::coordinator::RaftControlRequest request;
-  dingodb::pb::coordinator::RaftControlResponse response;
-
-  if (!FLAGS_host.empty() && FLAGS_port != 0) {
-    request.set_add_peer(FLAGS_host + ":" + std::to_string(FLAGS_port));
-  } else {
-    DINGO_LOG(ERROR) << "host or port is empty";
-    return;
-  }
-  request.set_op_type(::dingodb::pb::coordinator::RaftControlOp::AddPeer);
-
-  if (FLAGS_index == 0) {
-    request.set_node_index(dingodb::pb::coordinator::RaftControlNodeIndex::CoordinatorNodeIndex);
-  } else if (FLAGS_index == 1) {
-    request.set_node_index(dingodb::pb::coordinator::RaftControlNodeIndex::AutoIncrementNodeIndex);
-  } else {
-    DINGO_LOG(ERROR) << "index is error";
-    return;
-  }
-
-  stub.RaftControl(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG_INFO << response.DebugString();
-  }
-}
-
-void SendRaftRemovePeer(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
-  dingodb::pb::coordinator::RaftControlRequest request;
-  dingodb::pb::coordinator::RaftControlResponse response;
-
-  if (!FLAGS_host.empty() && FLAGS_port != 0) {
-    request.set_remove_peer(FLAGS_host + ":" + std::to_string(FLAGS_port));
-  } else {
-    DINGO_LOG(ERROR) << "host or port is empty";
-    return;
-  }
-  request.set_op_type(::dingodb::pb::coordinator::RaftControlOp::RemovePeer);
-
-  if (FLAGS_index == 0) {
-    request.set_node_index(dingodb::pb::coordinator::RaftControlNodeIndex::CoordinatorNodeIndex);
-  } else if (FLAGS_index == 1) {
-    request.set_node_index(dingodb::pb::coordinator::RaftControlNodeIndex::AutoIncrementNodeIndex);
-  } else {
-    DINGO_LOG(ERROR) << "index is error";
-    return;
-  }
-
-  stub.RaftControl(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG_INFO << response.DebugString();
-  }
-}
-
-void SendGetTaskList(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendGetTaskList(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::GetTaskListRequest request;
   dingodb::pb::coordinator::GetTaskListResponse response;
 
-  stub.GetTaskList(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG_INFO << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("GetTaskList", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG_INFO << response.DebugString();
 }
 
-void SendCleanTaskList(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+void SendCleanTaskList(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::coordinator::CleanTaskListRequest request;
   dingodb::pb::coordinator::CleanTaskListResponse response;
 
@@ -1381,16 +1069,7 @@ void SendCleanTaskList(brpc::Controller& cntl, dingodb::pb::coordinator::Coordin
   }
   request.set_task_list_id(std::stoull(FLAGS_id));
 
-  stub.CleanTaskList(&cntl, &request, &response, nullptr);
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
-    // bthread_usleep(FLAGS_timeout_ms * 1000L);
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << "Received response"
-                    << " request_attachment=" << cntl.request_attachment().size()
-                    << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
-    DINGO_LOG_INFO << response.DebugString();
-  }
+  auto status = coordinator_interaction->SendRequest("CleanTaskList", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG_INFO << response.DebugString();
 }

--- a/src/client/coordinator_client_function_incr.cc
+++ b/src/client/coordinator_client_function_incr.cc
@@ -35,6 +35,15 @@ DECLARE_string(id);
 // ./dingodb_client_coordinator -url=file://./coor_list -id=888 -start_id=110000 -method=UpdateAutoIncrement
 // ./dingodb_client_coordinator -url=file://./coor_list -id=888 -method=DeleteAutoIncrement
 
+void SendGetAutoIncrements(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
+  dingodb::pb::meta::GetAutoIncrementsRequest request;
+  dingodb::pb::meta::GetAutoIncrementsResponse response;
+
+  auto status = coordinator_interaction->SendRequest("GetAutoIncrements", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG_INFO << response.DebugString();
+}
+
 void SendGetAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::meta::GetAutoIncrementRequest request;
   dingodb::pb::meta::GetAutoIncrementResponse response;

--- a/src/client/coordinator_client_function_incr.cc
+++ b/src/client/coordinator_client_function_incr.cc
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+
 #include "common/logging.h"
+#include "coordinator/coordinator_interaction.h"
 #include "coordinator_client_function.h"
-//#include "proto/common.pb.h"
 
 DEFINE_uint64(start_id, 1, "Start id of auto_increment.");
 DEFINE_bool(force, true, "Force set auto increment.");
@@ -25,33 +27,15 @@ DEFINE_uint32(auto_increment_offset, 1, "SQL var auto_increment_offset.");
 DECLARE_bool(log_each_request);
 DECLARE_string(id);
 
-// use example:
+// usage example:
 
-// ./dingodb_client_coordinator -service_type=2 -coordinator_addr=172.20.3.96:22001 -id=888 -method=CreateAutoIncrement
+// ./dingodb_client_coordinator -url=file://./coor_list -id=888 -method=CreateAutoIncrement
+// ./dingodb_client_coordinator -url=file://./coor_list -id=888 -method=GetAutoIncrement
+// ./dingodb_client_coordinator -url=file://./coor_list -id=888 -generate_count=10000 -method=GenerateAutoIncrement
+// ./dingodb_client_coordinator -url=file://./coor_list -id=888 -start_id=110000 -method=UpdateAutoIncrement
+// ./dingodb_client_coordinator -url=file://./coor_list -id=888 -method=DeleteAutoIncrement
 
-// ./dingodb_client_coordinator -service_type=2 -coordinator_addr=172.20.3.96:22001 -id=888 -method=GetAutoIncrement
-
-// ./dingodb_client_coordinator -service_type=2 -coordinator_addr=172.20.3.96:22001 -id=888 -generate_count=10000
-// -method=GenerateAutoIncrement
-
-// ./dingodb_client_coordinator -service_type=2 -coordinator_addr=172.20.3.96:22001 -id=888 -start_id=110000
-// -method=UpdateAutoIncrement
-
-// ./dingodb_client_coordinator -service_type=2 -coordinator_addr=172.20.3.96:22001 -id=888 -method=DeleteAutoIncrement
-
-template <typename T>
-static void ProcessResponse(brpc::Controller& cntl, T& response, std::string func_name) {
-  if (cntl.Failed()) {
-    DINGO_LOG(WARNING) << func_name << " Fail to send request to : " << cntl.ErrorText();
-    return;
-  }
-
-  if (FLAGS_log_each_request) {
-    DINGO_LOG(INFO) << func_name << " Received response: " << response.Utf8DebugString();
-  }
-}
-
-void SendGetAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub) {
+void SendGetAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::meta::GetAutoIncrementRequest request;
   dingodb::pb::meta::GetAutoIncrementResponse response;
 
@@ -63,11 +47,12 @@ void SendGetAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaService
   }
   table_id->set_entity_id(std::stol(FLAGS_id));
 
-  stub.GetAutoIncrement(&cntl, &request, &response, nullptr);
-  ProcessResponse<dingodb::pb::meta::GetAutoIncrementResponse>(cntl, response, __FUNCTION__);
+  auto status = coordinator_interaction->SendRequest("GetAutoIncrement", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG_INFO << response.DebugString();
 }
 
-void SendCreateAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub) {
+void SendCreateAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::meta::CreateAutoIncrementRequest request;
   dingodb::pb::meta::CreateAutoIncrementResponse response;
 
@@ -81,11 +66,12 @@ void SendCreateAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaServ
 
   request.set_start_id(FLAGS_start_id);
 
-  stub.CreateAutoIncrement(&cntl, &request, &response, nullptr);
-  ProcessResponse<dingodb::pb::meta::CreateAutoIncrementResponse>(cntl, response, __FUNCTION__);
+  auto status = coordinator_interaction->SendRequest("CreateAutoIncrement", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG_INFO << response.DebugString();
 }
 
-void SendUpdateAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub) {
+void SendUpdateAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::meta::UpdateAutoIncrementRequest request;
   dingodb::pb::meta::UpdateAutoIncrementResponse response;
 
@@ -100,11 +86,12 @@ void SendUpdateAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaServ
   request.set_start_id(FLAGS_start_id);
   request.set_force(FLAGS_force);
 
-  stub.UpdateAutoIncrement(&cntl, &request, &response, nullptr);
-  ProcessResponse<dingodb::pb::meta::UpdateAutoIncrementResponse>(cntl, response, __FUNCTION__);
+  auto status = coordinator_interaction->SendRequest("UpdateAutoIncrement", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG_INFO << response.DebugString();
 }
 
-void SendGenerateAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub) {
+void SendGenerateAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::meta::GenerateAutoIncrementRequest request;
   dingodb::pb::meta::GenerateAutoIncrementResponse response;
 
@@ -120,11 +107,12 @@ void SendGenerateAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaSe
   request.set_auto_increment_increment(FLAGS_auto_increment_increment);
   request.set_auto_increment_offset(FLAGS_auto_increment_offset);
 
-  stub.GenerateAutoIncrement(&cntl, &request, &response, nullptr);
-  ProcessResponse<dingodb::pb::meta::GenerateAutoIncrementResponse>(cntl, response, __FUNCTION__);
+  auto status = coordinator_interaction->SendRequest("GenerateAutoIncrement", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG_INFO << response.DebugString();
 }
 
-void SendDeleteAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& stub) {
+void SendDeleteAutoIncrement(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {
   dingodb::pb::meta::DeleteAutoIncrementRequest request;
   dingodb::pb::meta::DeleteAutoIncrementResponse response;
 
@@ -136,6 +124,7 @@ void SendDeleteAutoIncrement(brpc::Controller& cntl, dingodb::pb::meta::MetaServ
   }
   table_id->set_entity_id(std::stol(FLAGS_id));
 
-  stub.DeleteAutoIncrement(&cntl, &request, &response, nullptr);
-  ProcessResponse<dingodb::pb::meta::DeleteAutoIncrementResponse>(cntl, response, __FUNCTION__);
+  auto status = coordinator_interaction->SendRequest("DeleteAutoIncrement", request, response);
+  DINGO_LOG(INFO) << "SendRequest status=" << status;
+  DINGO_LOG_INFO << response.DebugString();
 }

--- a/src/client/coordinator_client_function_meta.cc
+++ b/src/client/coordinator_client_function_meta.cc
@@ -213,7 +213,8 @@ void SendCreateTableId(std::shared_ptr<dingodb::CoordinatorInteraction> coordina
   DINGO_LOG_INFO << response.DebugString();
 }
 
-void SendCreateTable(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction, bool with_table_id) {
+void SendCreateTable(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction, bool with_table_id,
+                     bool with_increment) {
   dingodb::pb::meta::CreateTableRequest request;
   dingodb::pb::meta::CreateTableResponse response;
 
@@ -252,14 +253,22 @@ void SendCreateTable(std::shared_ptr<dingodb::CoordinatorInteraction> coordinato
     std::string column_name("test_columen_");
     column_name.append(std::to_string(i));
     column->set_name(column_name);
-    column->set_sql_type(::dingodb::pb::meta::SqlType::SQL_TYPE_INTEGER);
-    column->set_element_type(::dingodb::pb::meta::ElementType::ELEM_TYPE_BYTES);
+    column->set_sql_type(::dingodb::pb::meta::SqlType::SQL_TYPE_BIGINT);
+    column->set_element_type(::dingodb::pb::meta::ElementType::ELEM_TYPE_INT64);
     column->set_precision(100);
     column->set_nullable(false);
     column->set_indexofkey(7);
     column->set_has_default_val(false);
     column->set_default_val("0");
+
+    if (with_increment && i == 0) {
+      column->set_is_auto_increment(true);
+    }
   }
+  if (with_increment) {
+    table_definition->set_auto_increment(100);
+  }
+
   // map<string, Index> indexes = 3;
   // uint32 version = 4;
   table_definition->set_version(1);

--- a/src/common/meta_control.h
+++ b/src/common/meta_control.h
@@ -42,13 +42,16 @@ class MetaControl {
   virtual void OnLeaderStart(int64_t term) = 0;
   virtual int GetAppliedTermAndIndex(uint64_t &term, uint64_t &index) = 0;
 
+  // Get raft leader's server location for sdk use
+  virtual void GetLeaderLocation(pb::common::Location &leader_server_location) = 0;
+
   // set raft_node to coordinator_control
   virtual void SetRaftNode(std::shared_ptr<RaftNode> raft_node) = 0;
   virtual std::shared_ptr<RaftNode> GetRaftNode() = 0;
 
   // on_apply callback
   virtual void ApplyMetaIncrement(pb::coordinator_internal::MetaIncrement &meta_increment, bool is_leader,
-                                  uint64_t term, uint64_t index, google::protobuf::Message* response) = 0;
+                                  uint64_t term, uint64_t index, google::protobuf::Message *response) = 0;
 
   // prepare snapshot for raft snapshot
   // return: Snapshot

--- a/src/coordinator/auto_increment_control.cc
+++ b/src/coordinator/auto_increment_control.cc
@@ -25,6 +25,7 @@
 #include "common/synchronization.h"
 #include "coordinator/coordinator_interaction.h"
 #include "engine/snapshot.h"
+#include "server/server.h"
 
 namespace dingodb {
 
@@ -435,7 +436,7 @@ butil::Status AutoIncrementControl::SendCreateAutoIncrementInternal(const uint64
   table_id_ptr->set_entity_id(table_id);
   request.set_start_id(auto_increment);
 
-  return CoordinatorInteraction::GetAutoIncrementInstance()->SendRequest("CreateAutoIncrement", request, response);
+  return Server::GetInstance()->GetCoordinatorInteractionIncr()->SendRequest("CreateAutoIncrement", request, response);
 }
 
 void AutoIncrementControl::SendUpdateAutoIncrementInternal(const uint64_t table_id, const uint64_t auto_increment) {
@@ -455,7 +456,7 @@ void AutoIncrementControl::SendUpdateAutoIncrementInternal(const uint64_t table_
     request.set_force(true);
 
     butil::Status status =
-        CoordinatorInteraction::GetAutoIncrementInstance()->SendRequest("UpdateAutoIncrement", request, response);
+        Server::GetInstance()->GetCoordinatorInteractionIncr()->SendRequest("UpdateAutoIncrement", request, response);
     if (status.error_code() != pb::error::Errno::OK) {
       LOG(ERROR) << "error, code: " << status.error_code() << ", message: " << status.error_str();
     }
@@ -475,7 +476,7 @@ void AutoIncrementControl::SendDeleteAutoIncrementInternal(const uint64_t table_
     table_id_ptr->set_entity_id(table_id);
 
     butil::Status status =
-        CoordinatorInteraction::GetAutoIncrementInstance()->SendRequest("DeleteAutoIncrement", request, response);
+        Server::GetInstance()->GetCoordinatorInteractionIncr()->SendRequest("DeleteAutoIncrement", request, response);
     if (status.error_code() != pb::error::Errno::OK) {
       LOG(ERROR) << "error, code: " << status.error_code() << ", message: " << status.error_str();
     }

--- a/src/coordinator/auto_increment_control.cc
+++ b/src/coordinator/auto_increment_control.cc
@@ -63,9 +63,15 @@ butil::Status AutoIncrementControl::GetAutoIncrement(uint64_t table_id, uint64_t
   return butil::Status::OK();
 }
 
+butil::Status AutoIncrementControl::GetAutoIncrements(butil::FlatMap<uint64_t, uint64_t>& auto_increments) {
+  BAIDU_SCOPED_LOCK(auto_increment_map_mutex_);
+  auto_increments = auto_increment_map_;
+  return butil::Status::OK();
+}
+
 butil::Status AutoIncrementControl::CreateAutoIncrement(uint64_t table_id, uint64_t start_id,
                                                         pb::coordinator_internal::MetaIncrement& meta_increment) {
-  DINGO_LOG(INFO) << "create auto increment.";
+  DINGO_LOG(INFO) << "create auto increment table id: " << table_id << " start id: " << start_id << "";
   {
     BAIDU_SCOPED_LOCK(auto_increment_map_mutex_);
     if (auto_increment_map_.seek(table_id) != nullptr) {
@@ -155,7 +161,7 @@ butil::Status AutoIncrementControl::DeleteAutoIncrement(uint64_t table_id,
   return butil::Status::OK();
 }
 
-void AutoIncrementControl::GetLeaderLocation(pb::common::Location* leader_server_location_ptr) {
+void AutoIncrementControl::GetLeaderLocation(pb::common::Location& leader_server_location) {
   if (raft_node_ == nullptr) {
     DINGO_LOG(ERROR) << "raft_node_ is nullptr";
     return;
@@ -172,7 +178,7 @@ void AutoIncrementControl::GetLeaderLocation(pb::common::Location* leader_server
   }
 
   // GetServerLocation
-  GetServerLocation(leader_raft_location, *leader_server_location_ptr);
+  GetServerLocation(leader_raft_location, leader_server_location);
 }
 
 void AutoIncrementControl::GetServerLocation(pb::common::Location& raft_location,

--- a/src/coordinator/auto_increment_control.cc
+++ b/src/coordinator/auto_increment_control.cc
@@ -405,7 +405,8 @@ butil::Status AutoIncrementControl::CheckAutoIncrementInTableDefinition(
     const auto& column = table_definition.columns(i);
     if (column.is_auto_increment()) {
       if (has_auto_increment_column) {
-        return butil::Status(pb::error::Errno::ETABLE_DEFINITION_ILLEGAL, "table definition illegal");
+        return butil::Status(pb::error::Errno::ETABLE_DEFINITION_ILLEGAL,
+                             "table definition illegal, multi auto_increment column");
       } else {
         switch (column.element_type()) {
           case pb::meta::ElementType::ELEM_TYPE_INT32:
@@ -419,12 +420,14 @@ butil::Status AutoIncrementControl::CheckAutoIncrementInTableDefinition(
             if (table_definition.auto_increment() > 0) {
               has_auto_increment_column = true;
             } else {
-              return butil::Status(pb::error::Errno::ETABLE_DEFINITION_ILLEGAL, "table definition illegal");
+              return butil::Status(pb::error::Errno::ETABLE_DEFINITION_ILLEGAL,
+                                   "table definition illegal, auto_increment must be greater than 0");
             }
             break;
           }
           default: {
-            return butil::Status(pb::error::Errno::ETABLE_DEFINITION_ILLEGAL, "table definition illegal");
+            return butil::Status(pb::error::Errno::ETABLE_DEFINITION_ILLEGAL,
+                                 "table definition illegal, auto_increment column type illegal");
           }
         }
       }

--- a/src/coordinator/auto_increment_control.h
+++ b/src/coordinator/auto_increment_control.h
@@ -47,6 +47,7 @@ class AutoIncrementControl : public MetaControl {
   static bool Init();
   static bool Recover();
 
+  butil::Status GetAutoIncrements(butil::FlatMap<uint64_t, uint64_t> &auto_increments);
   butil::Status GetAutoIncrement(uint64_t table_id, uint64_t &start_id);
   butil::Status CreateAutoIncrement(uint64_t table_id, uint64_t start_id,
                                     pb::coordinator_internal::MetaIncrement &meta_increment);
@@ -58,7 +59,7 @@ class AutoIncrementControl : public MetaControl {
   butil::Status DeleteAutoIncrement(uint64_t table_id, pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // Get raft leader's server location
-  void GetLeaderLocation(pb::common::Location *leader_server_location_ptr);
+  void GetLeaderLocation(pb::common::Location &leader_server_location) override;
 
   // use raft_location to get server_location
   // in: raft_location

--- a/src/coordinator/auto_increment_control.h
+++ b/src/coordinator/auto_increment_control.h
@@ -47,15 +47,15 @@ class AutoIncrementControl : public MetaControl {
   static bool Init();
   static bool Recover();
 
-  pb::error::Errno GetAutoIncrement(uint64_t table_id, uint64_t &start_id);
-  pb::error::Errno CreateAutoIncrement(uint64_t table_id, uint64_t start_id,
-                                       pb::coordinator_internal::MetaIncrement &meta_increment);
-  pb::error::Errno UpdateAutoIncrement(uint64_t table_id, uint64_t start_id, bool force,
-                                       pb::coordinator_internal::MetaIncrement &meta_increment);
-  pb::error::Errno GenerateAutoIncrement(uint64_t table_id, uint32_t count, uint32_t auto_increment_increment,
-                                         uint32_t auto_increment_offset,
-                                         pb::coordinator_internal::MetaIncrement &meta_increment);
-  pb::error::Errno DeleteAutoIncrement(uint64_t table_id, pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status GetAutoIncrement(uint64_t table_id, uint64_t &start_id);
+  butil::Status CreateAutoIncrement(uint64_t table_id, uint64_t start_id,
+                                    pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status UpdateAutoIncrement(uint64_t table_id, uint64_t start_id, bool force,
+                                    pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status GenerateAutoIncrement(uint64_t table_id, uint32_t count, uint32_t auto_increment_increment,
+                                      uint32_t auto_increment_offset,
+                                      pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status DeleteAutoIncrement(uint64_t table_id, pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // Get raft leader's server location
   void GetLeaderLocation(pb::common::Location *leader_server_location_ptr);
@@ -87,8 +87,8 @@ class AutoIncrementControl : public MetaControl {
   int SaveAutoIncrement(std::string &auto_increment_data);
   int LoadAutoIncrement(const std::string &auto_increment_file);
 
-  static pb::error::Errno CheckAutoIncrementInTableDefinition(const pb::meta::TableDefinition &table_definition,
-                                                              bool &has_auto_increment_column);
+  static butil::Status CheckAutoIncrementInTableDefinition(const pb::meta::TableDefinition &table_definition,
+                                                           bool &has_auto_increment_column);
 
   static butil::Status SendCreateAutoIncrementInternal(uint64_t table_id, uint64_t auto_increment);
   static void SendUpdateAutoIncrementInternal(uint64_t table_id, uint64_t auto_increment);

--- a/src/coordinator/coordinator_control.h
+++ b/src/coordinator/coordinator_control.h
@@ -28,6 +28,7 @@
 #include "bthread/types.h"
 #include "butil/containers/flat_map.h"
 #include "butil/scoped_lock.h"
+#include "butil/status.h"
 #include "butil/strings/stringprintf.h"
 #include "common/logging.h"
 #include "common/meta_control.h"
@@ -79,8 +80,9 @@ class CoordinatorControl : public MetaControl {
   // SubmitMetaIncrement
   // in:  meta_increment
   // return: 0 or -1
-  int SubmitMetaIncrement(pb::coordinator_internal::MetaIncrement &meta_increment);
-  int SubmitMetaIncrement(google::protobuf::Closure *done, pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status SubmitMetaIncrement(pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status SubmitMetaIncrement(google::protobuf::Closure *done,
+                                    pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // GetMemoryInfo
   void GetMemoryInfo(pb::coordinator::CoordinatorMemoryInfo &memory_info);
@@ -95,139 +97,138 @@ class CoordinatorControl : public MetaControl {
   void GetRaftLocation(pb::common::Location &server_location, pb::common::Location &raft_location);
 
   // query region info
-  pb::error::Errno QueryRegion(uint64_t region_id, pb::common::Region &region);
+  butil::Status QueryRegion(uint64_t region_id, pb::common::Region &region);
 
   // create region
   // in: resource_tag
   // out: new region id
   // return: errno
-  pb::error::Errno CreateRegion(const std::string &region_name, const std::string &resource_tag, int32_t replica_num,
-                                pb::common::Range region_range, uint64_t schema_id, uint64_t table_id,
-                                uint64_t &new_region_id, pb::coordinator_internal::MetaIncrement &meta_increment);
-  pb::error::Errno CreateRegion(const std::string &region_name, const std::string &resource_tag, int32_t replica_num,
-                                pb::common::Range region_range, uint64_t schema_id, uint64_t table_id,
-                                std::vector<uint64_t> &store_ids, uint64_t split_from_region_id,
-                                uint64_t &new_region_id, pb::coordinator_internal::MetaIncrement &meta_increment);
-  pb::error::Errno CreateRegionForSplit(const std::string &region_name, const std::string &resource_tag,
-                                        pb::common::Range region_range, uint64_t schema_id, uint64_t table_id,
-                                        uint64_t split_from_region_id, uint64_t &new_region_id,
-                                        pb::coordinator_internal::MetaIncrement &meta_increment);
-  pb::error::Errno CreateRegionForSplitInternal(uint64_t split_from_region_id, uint64_t &new_region_id,
-                                                pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status CreateRegion(const std::string &region_name, const std::string &resource_tag, int32_t replica_num,
+                             pb::common::Range region_range, uint64_t schema_id, uint64_t table_id,
+                             uint64_t &new_region_id, pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status CreateRegion(const std::string &region_name, const std::string &resource_tag, int32_t replica_num,
+                             pb::common::Range region_range, uint64_t schema_id, uint64_t table_id,
+                             std::vector<uint64_t> &store_ids, uint64_t split_from_region_id, uint64_t &new_region_id,
+                             pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status CreateRegionForSplit(const std::string &region_name, const std::string &resource_tag,
+                                     pb::common::Range region_range, uint64_t schema_id, uint64_t table_id,
+                                     uint64_t split_from_region_id, uint64_t &new_region_id,
+                                     pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status CreateRegionForSplitInternal(uint64_t split_from_region_id, uint64_t &new_region_id,
+                                             pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // drop region
   // in:  region_id
   // in:  need_update_table_range
   // return: errno
-  pb::error::Errno DropRegion(uint64_t region_id, pb::coordinator_internal::MetaIncrement &meta_increment);
-  pb::error::Errno DropRegion(uint64_t region_id, bool need_update_table_range,
-                              pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status DropRegion(uint64_t region_id, pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status DropRegion(uint64_t region_id, bool need_update_table_range,
+                           pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // drop region permanently
   // in:  region_id
   // return: errno
-  pb::error::Errno DropRegionPermanently(uint64_t region_id, pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status DropRegionPermanently(uint64_t region_id, pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // split region
-  pb::error::Errno SplitRegion(uint64_t split_from_region_id, uint64_t split_to_region_id,
-                               std::string split_watershed_key,
-                               pb::coordinator_internal::MetaIncrement &meta_increment);
-  pb::error::Errno SplitRegionWithTaskList(uint64_t split_from_region_id, uint64_t split_to_region_id,
-                                           std::string split_watershed_key,
-                                           pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status SplitRegion(uint64_t split_from_region_id, uint64_t split_to_region_id, std::string split_watershed_key,
+                            pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status SplitRegionWithTaskList(uint64_t split_from_region_id, uint64_t split_to_region_id,
+                                        std::string split_watershed_key,
+                                        pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // merge region
-  pb::error::Errno MergeRegionWithTaskList(uint64_t merge_from_region_id, uint64_t merge_to_region_id,
-                                           pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status MergeRegionWithTaskList(uint64_t merge_from_region_id, uint64_t merge_to_region_id,
+                                        pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // change peer region
-  pb::error::Errno ChangePeerRegionWithTaskList(uint64_t region_id, std::vector<uint64_t> &new_store_ids,
-                                                pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status ChangePeerRegionWithTaskList(uint64_t region_id, std::vector<uint64_t> &new_store_ids,
+                                             pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // create schema
   // in: parent_schema_id
   // in: schema_name
   // out: new schema_id
   // return: errno
-  pb::error::Errno CreateSchema(uint64_t parent_schema_id, std::string schema_name, uint64_t &new_schema_id,
-                                pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status CreateSchema(uint64_t parent_schema_id, std::string schema_name, uint64_t &new_schema_id,
+                             pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // drop schema
   // in: parent_schema_id
   // in: schema_id
   // return: 0 or -1
-  pb::error::Errno DropSchema(uint64_t parent_schema_id, uint64_t schema_id,
-                              pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status DropSchema(uint64_t parent_schema_id, uint64_t schema_id,
+                           pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // create schema
   // in: schema_id
   // out: new table_id
   // return: errno
-  pb::error::Errno CreateTableId(uint64_t schema_id, uint64_t &new_table_id,
-                                 pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status CreateTableId(uint64_t schema_id, uint64_t &new_table_id,
+                              pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // create schema
   // in: schema_id
   // in: table_definition
   // out: new table_id
   // return: errno
-  pb::error::Errno CreateTable(uint64_t schema_id, const pb::meta::TableDefinition &table_definition,
-                               uint64_t &new_table_id, pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status CreateTable(uint64_t schema_id, const pb::meta::TableDefinition &table_definition,
+                            uint64_t &new_table_id, pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // create store
   // in: cluster_id
   // out: store_id, keyring
   // return: 0 or -1
-  pb::error::Errno CreateStore(uint64_t cluster_id, uint64_t &store_id, std::string &keyring,
-                               pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status CreateStore(uint64_t cluster_id, uint64_t &store_id, std::string &keyring,
+                            pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // delete store
   // in: cluster_id, store_id, keyring
-  // return: 0 or -1
-  pb::error::Errno DeleteStore(uint64_t cluster_id, uint64_t store_id, std::string keyring,
-                               pb::coordinator_internal::MetaIncrement &meta_increment);
+  // return: errno
+  butil::Status DeleteStore(uint64_t cluster_id, uint64_t store_id, std::string keyring,
+                            pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // create executor
   // in: cluster_id
   // in: executor
   // out: executor
   // return: errno
-  pb::error::Errno CreateExecutor(uint64_t cluster_id, pb::common::Executor &executor,
-                                  pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status CreateExecutor(uint64_t cluster_id, pb::common::Executor &executor,
+                               pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // delete executor
   // in: cluster_id, executor
   // return: 0 or -1
-  pb::error::Errno DeleteExecutor(uint64_t cluster_id, const pb::common::Executor &executor,
-                                  pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status DeleteExecutor(uint64_t cluster_id, const pb::common::Executor &executor,
+                               pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // create executor_user
   // in: cluster_id
   // out: executor_user
   // return: errno
-  pb::error::Errno CreateExecutorUser(uint64_t cluster_id, pb::common::ExecutorUser &executor_user,
-                                      pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status CreateExecutorUser(uint64_t cluster_id, pb::common::ExecutorUser &executor_user,
+                                   pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // update executor_user
   // in: cluster_id
   // out: executor_user
   // return: errno
-  pb::error::Errno UpdateExecutorUser(uint64_t cluster_id, const pb::common::ExecutorUser &executor_user,
-                                      const pb::common::ExecutorUser &executor_user_update,
-                                      pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status UpdateExecutorUser(uint64_t cluster_id, const pb::common::ExecutorUser &executor_user,
+                                   const pb::common::ExecutorUser &executor_user_update,
+                                   pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // delete executor_user
   // in: cluster_id
   // out: executor_user
   // return: errno
-  pb::error::Errno DeleteExecutorUser(uint64_t cluster_id, pb::common::ExecutorUser &executor_user,
-                                      pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status DeleteExecutorUser(uint64_t cluster_id, pb::common::ExecutorUser &executor_user,
+                                   pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // get executor_user_map
   // in: cluster_id
   // out: executor_user_map
   // return: errno
-  pb::error::Errno GetExecutorUserMap(uint64_t cluster_id, pb::common::ExecutorUserMap &executor_user_map);
+  butil::Status GetExecutorUserMap(uint64_t cluster_id, pb::common::ExecutorUserMap &executor_user_map);
 
   // update executor map with new Executor info
   // return new epoch
@@ -253,7 +254,7 @@ class CoordinatorControl : public MetaControl {
   void GetStoreMetrics(uint64_t store_id, std::vector<pb::common::StoreMetrics> &store_metrics);
 
   // get orphan region
-  pb::error::Errno GetOrphanRegion(uint64_t store_id, std::map<uint64_t, pb::common::RegionMetrics> &orphan_regions);
+  butil::Status GetOrphanRegion(uint64_t store_id, std::map<uint64_t, pb::common::RegionMetrics> &orphan_regions);
 
   // get store operation
   void GetStoreOperation(uint64_t store_id, pb::coordinator::StoreOperation &store_operation);
@@ -262,12 +263,12 @@ class CoordinatorControl : public MetaControl {
   // CleanStoreOperation
   // in:  store_id
   // return: 0 or -1
-  pb::error::Errno CleanStoreOperation(uint64_t store_id, pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status CleanStoreOperation(uint64_t store_id, pb::coordinator_internal::MetaIncrement &meta_increment);
 
-  pb::error::Errno AddStoreOperation(const pb::coordinator::StoreOperation &store_operation,
+  butil::Status AddStoreOperation(const pb::coordinator::StoreOperation &store_operation,
+                                  pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status RemoveStoreOperation(uint64_t store_id, uint64_t region_cmd_id,
                                      pb::coordinator_internal::MetaIncrement &meta_increment);
-  pb::error::Errno RemoveStoreOperation(uint64_t store_id, uint64_t region_cmd_id,
-                                        pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // UpdateRegionMapAndStoreOperation
   void UpdateRegionMapAndStoreOperation(const pb::common::StoreMetrics &store_metrics,
@@ -331,7 +332,7 @@ class CoordinatorControl : public MetaControl {
   // in: schema_id
   // in: table_id
   // out: TableMetricsWithId
-  pb::error::Errno GetTableMetrics(uint64_t schema_id, uint64_t table_id, pb::meta::TableMetricsWithId &table_metrics);
+  butil::Status GetTableMetrics(uint64_t schema_id, uint64_t table_id, pb::meta::TableMetricsWithId &table_metrics);
 
   // update store metrics with new metrics
   // return new epoch
@@ -343,8 +344,8 @@ class CoordinatorControl : public MetaControl {
   // in: table_id
   // out: meta_increment
   // return: errno
-  pb::error::Errno DropTable(uint64_t schema_id, uint64_t table_id,
-                             pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status DropTable(uint64_t schema_id, uint64_t table_id,
+                          pb::coordinator_internal::MetaIncrement &meta_increment);
 
   // get coordinator_map
   void GetCoordinatorMap(uint64_t cluster_id, uint64_t &epoch, pb::common::Location &leader_location,
@@ -409,16 +410,16 @@ class CoordinatorControl : public MetaControl {
 
   // check if task in task_lis can advance
   // if task advance, this function will contruct meta_increment and apply to state_machine
-  pb::error::Errno ProcessTaskList();
+  butil::Status ProcessTaskList();
 
   // process single task
-  pb::error::Errno ProcessSingleTaskList(const pb::coordinator::TaskList &task_list,
-                                         pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status ProcessSingleTaskList(const pb::coordinator::TaskList &task_list,
+                                      pb::coordinator_internal::MetaIncrement &meta_increment);
   void ReleaseProcessTaskListStatus(const butil::Status &);
 
   bool DoTaskPreCheck(const pb::coordinator::TaskPreCheck &task_pre_check);
 
-  pb::error::Errno CleanTaskList(uint64_t task_list_id, pb::coordinator_internal::MetaIncrement &meta_increment);
+  butil::Status CleanTaskList(uint64_t task_list_id, pb::coordinator_internal::MetaIncrement &meta_increment);
 
  private:
   bool ValidateTaskListConflict(uint64_t region_id, uint64_t second_region_id);

--- a/src/coordinator/coordinator_control.h
+++ b/src/coordinator/coordinator_control.h
@@ -88,7 +88,7 @@ class CoordinatorControl : public MetaControl {
   void GetMemoryInfo(pb::coordinator::CoordinatorMemoryInfo &memory_info);
 
   // Get raft leader's server location for sdk use
-  void GetLeaderLocation(pb::common::Location &leader_server_location);
+  void GetLeaderLocation(pb::common::Location &leader_server_location) override;
 
   // use raft_location to get server_location
   // in: raft_location

--- a/src/coordinator/coordinator_control_coor.cc
+++ b/src/coordinator/coordinator_control_coor.cc
@@ -2383,6 +2383,21 @@ void CoordinatorControl::GetMemoryInfo(pb::coordinator::CoordinatorMemoryInfo& m
     memory_info.set_table_metrics_map_size(table_metrics_map_.MemorySize());
     memory_info.set_total_size(memory_info.total_size() + memory_info.table_metrics_map_size());
   }
+  {
+    memory_info.set_store_operation_map_count(store_operation_map_.Size());
+    memory_info.set_store_operation_map_size(store_operation_map_.MemorySize());
+    memory_info.set_total_size(memory_info.total_size() + memory_info.store_operation_map_size());
+  }
+  {
+    memory_info.set_executor_user_map_count(executor_user_map_.Size());
+    memory_info.set_executor_user_map_size(executor_user_map_.MemorySize());
+    memory_info.set_total_size(memory_info.total_size() + memory_info.executor_user_map_size());
+  }
+  {
+    memory_info.set_task_list_map_count(task_list_map_.Size());
+    memory_info.set_task_list_map_size(task_list_map_.MemorySize());
+    memory_info.set_total_size(memory_info.total_size() + memory_info.task_list_map_size());
+  }
 }
 
 void CoordinatorControl::GetStoreOperation(uint64_t store_id, pb::coordinator::StoreOperation& store_operation) {

--- a/src/coordinator/coordinator_control_fsm.cc
+++ b/src/coordinator/coordinator_control_fsm.cc
@@ -25,6 +25,7 @@
 #include "brpc/channel.h"
 #include "brpc/closure_guard.h"
 #include "butil/scoped_lock.h"
+#include "butil/status.h"
 #include "butil/strings/string_split.h"
 #include "common/constant.h"
 #include "common/helper.h"
@@ -1433,12 +1434,12 @@ void CoordinatorControl::ApplyMetaIncrement(pb::coordinator_internal::MetaIncrem
 
 // SubmitMetaIncrement
 // commit meta increment to raft meta engine, with no closure
-int CoordinatorControl::SubmitMetaIncrement(pb::coordinator_internal::MetaIncrement& meta_increment) {
+butil::Status CoordinatorControl::SubmitMetaIncrement(pb::coordinator_internal::MetaIncrement& meta_increment) {
   return SubmitMetaIncrement(nullptr, meta_increment);
 }
 
-int CoordinatorControl::SubmitMetaIncrement(google::protobuf::Closure* done,
-                                            pb::coordinator_internal::MetaIncrement& meta_increment) {
+butil::Status CoordinatorControl::SubmitMetaIncrement(google::protobuf::Closure* done,
+                                                      pb::coordinator_internal::MetaIncrement& meta_increment) {
   LogMetaIncrementSize(meta_increment);
 
   std::shared_ptr<Context> const ctx = std::make_shared<Context>();
@@ -1451,9 +1452,9 @@ int CoordinatorControl::SubmitMetaIncrement(google::protobuf::Closure* done,
   auto status = engine_->MetaPut(ctx, meta_increment);
   if (!status.ok()) {
     DINGO_LOG(ERROR) << "ApplyMetaIncrement failed, errno=" << status.error_code() << " errmsg=" << status.error_str();
-    return -1;
+    return status;
   }
-  return 0;
+  return butil::Status::OK();
 }
 
 }  // namespace dingodb

--- a/src/coordinator/coordinator_control_meta.cc
+++ b/src/coordinator/coordinator_control_meta.cc
@@ -410,7 +410,8 @@ butil::Status CoordinatorControl::CreateTable(uint64_t schema_id, const pb::meta
   table_name_map_safe_temp_.Get(std::to_string(schema_id) + table_definition.name(), value);
   if (value != 0) {
     DINGO_LOG(INFO) << " Createtable table_name is exist " << table_definition.name();
-    return butil::Status(pb::error::Errno::ETABLE_EXISTS, "table_name is exist");
+    return butil::Status(pb::error::Errno::ETABLE_EXISTS, "table_name[%s] is exist in get",
+                         table_definition.name().c_str());
   }
 
   // if new_table_id is not given, create a new table_id
@@ -437,7 +438,8 @@ butil::Status CoordinatorControl::CreateTable(uint64_t schema_id, const pb::meta
   if (table_name_map_safe_temp_.PutIfAbsent(std::to_string(schema_id) + table_definition.name(), new_table_id) < 0) {
     DINGO_LOG(INFO) << " CreateTable table_name" << table_definition.name()
                     << " is exist, when insert new_table_id=" << new_table_id;
-    return butil::Status(pb::error::Errno::ETABLE_EXISTS, "table_name is exist");
+    return butil::Status(pb::error::Errno::ETABLE_EXISTS, "table_name[%s] is exist in put if absent",
+                         table_definition.name().c_str());
   }
 
   // create table

--- a/src/coordinator/coordinator_interaction.cc
+++ b/src/coordinator/coordinator_interaction.cc
@@ -66,7 +66,7 @@ bool CoordinatorInteraction::InitByNameService(const std::string& service_name, 
 
   use_service_name_ = true;
 
-  DINGO_LOG(INFO) << "Init channel by service_name " << service_name;
+  DINGO_LOG(INFO) << "Init channel by service_name " << service_name << " service_type=" << service_type;
 
   return true;
 }

--- a/src/coordinator/coordinator_interaction.cc
+++ b/src/coordinator/coordinator_interaction.cc
@@ -24,10 +24,6 @@
 
 namespace dingodb {
 
-DEFINE_string(coor_url, "",
-              "coor service name, e.g. file://<path>, list://<addr1>,<addr2>..., bns://<bns-name>, "
-              "consul://<service-name>, http://<url>, https://<url>");
-
 bool CoordinatorInteraction::Init(const std::string& addr, uint32_t service_type) {
   service_type_ = service_type;
   endpoints_ = Helper::StrToEndpoints(addr);

--- a/src/coordinator/coordinator_interaction.h
+++ b/src/coordinator/coordinator_interaction.h
@@ -63,11 +63,6 @@ class CoordinatorInteraction {
 
   const ::google::protobuf::ServiceDescriptor* GetServiceDescriptor() const;
 
-  static CoordinatorInteraction* GetAutoIncrementInstance() {
-    static CoordinatorInteraction instance;
-    return &instance;
-  }
-
   void SetLeaderAddress(const butil::EndPoint& addr);
 
  private:

--- a/src/server/coordinator_service.cc
+++ b/src/server/coordinator_service.cc
@@ -638,7 +638,9 @@ void CoordinatorServiceImpl::GetCoordinatorMap(google::protobuf::RpcController *
   }
 
   // get autoincrement leader location
-  auto_increment_control_->GetLeaderLocation(response->mutable_auto_increment_leader_location());
+  pb::common::Location auto_increment_leader_location;
+  auto_increment_control_->GetLeaderLocation(auto_increment_leader_location);
+  response->mutable_auto_increment_leader_location()->CopyFrom(auto_increment_leader_location);
 }
 
 // Region services

--- a/src/server/meta_service.h
+++ b/src/server/meta_service.h
@@ -44,8 +44,11 @@ class MetaServiceImpl : public pb::meta::MetaService {
 
   template <typename T>
   void RedirectAutoIncrementResponse(T response) {
+    pb::common::Location leader_location;
+    this->auto_increment_control_->GetLeaderLocation(leader_location);
+
     auto* error_in_response = response->mutable_error();
-    auto_increment_control_->GetLeaderLocation(error_in_response->mutable_leader_location());
+    error_in_response->mutable_leader_location()->CopyFrom(leader_location);
     error_in_response->set_errcode(Errno::ERAFT_NOTLEADER);
   }
 
@@ -86,6 +89,8 @@ class MetaServiceImpl : public pb::meta::MetaService {
   void DropSchema(google::protobuf::RpcController* controller, const pb::meta::DropSchemaRequest* request,
                   pb::meta::DropSchemaResponse* response, google::protobuf::Closure* done) override;
 
+  void GetAutoIncrements(google::protobuf::RpcController* controller, const pb::meta::GetAutoIncrementsRequest* request,
+                         pb::meta::GetAutoIncrementsResponse* response, google::protobuf::Closure* done) override;
   void GetAutoIncrement(google::protobuf::RpcController* controller, const pb::meta::GetAutoIncrementRequest* request,
                         pb::meta::GetAutoIncrementResponse* response, google::protobuf::Closure* done) override;
   void CreateAutoIncrement(google::protobuf::RpcController* controller,

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -46,7 +46,9 @@
 
 namespace dingodb {
 
-DECLARE_string(coor_url);
+DEFINE_string(coor_url, "",
+              "coor service name, e.g. file://<path>, list://<addr1>,<addr2>..., bns://<bns-name>, "
+              "consul://<service-name>, http://<url>, https://<url>");
 
 void Server::SetRole(pb::common::ClusterRole role) { role_ = role; }
 

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -194,17 +194,17 @@ bool Server::InitCoordinatorInteraction() {
 }
 
 bool Server::InitCoordinatorInteractionForAutoIncrement() {
-  auto* coordinator_interaction = CoordinatorInteraction::GetAutoIncrementInstance();
+  coordinator_interaction_incr_ = std::make_shared<CoordinatorInteraction>();
 
   auto config = ConfigManager::GetInstance()->GetConfig(role_);
 
   if (!FLAGS_coor_url.empty()) {
-    return coordinator_interaction->InitByNameService(FLAGS_coor_url,
-                                                      pb::common::CoordinatorServiceType::ServiceTypeAutoIncrement);
+    return coordinator_interaction_incr_->InitByNameService(
+        FLAGS_coor_url, pb::common::CoordinatorServiceType::ServiceTypeAutoIncrement);
 
   } else {
-    return coordinator_interaction->Init(config->GetString("coordinator.peers"),
-                                         pb::common::CoordinatorServiceType::ServiceTypeAutoIncrement);
+    return coordinator_interaction_incr_->Init(config->GetString("coordinator.peers"),
+                                               pb::common::CoordinatorServiceType::ServiceTypeAutoIncrement);
   }
 }
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -111,6 +111,7 @@ class Server {
   void SetRaftEndpoint(const butil::EndPoint& endpoint) { raft_endpoint_ = endpoint; }
 
   std::shared_ptr<CoordinatorInteraction> GetCoordinatorInteraction() { return coordinator_interaction_; }
+  std::shared_ptr<CoordinatorInteraction> GetCoordinatorInteractionIncr() { return coordinator_interaction_incr_; }
 
   std::shared_ptr<Engine> GetEngine() { return engine_; }
 


### PR DESCRIPTION
[refactor][coordinator] Use coordinator interaction to refactor coordinator_client.

Now we need to get a coor_list file to use coordinator_client.
The "coor_list" file can be found in coordinator/store 's conf directory after using deploy.sh to get a new cluster.

Then we can use like this:

`./dingodb_client_coordinator --url=file://./coor_list --method=GetStoreMap`

If you just place coor_list in pwd, you can omit the --url parameter, like this:

`./dingodb_client_coordinator --method=GetStoreMap`

The client will default use file://./coor_list as the --url parameter value.

If you need to call raft control functions (RaftAddPeer) or node service functions( ChangeLogLevel),  you still need to pass --addr=host:port  which is the node you want to access, like this:

`./dingodb_client_coordinator --method=GetLogLevel --addr=192.168.x.x:22001`


