### PR TITLE
    [feat][store] Add CompareAndSet.

### DIFF
--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -29,6 +29,7 @@ enum CmdType {
   DELETERANGE = 3;
   DELETEBATCH = 4;
   SPLIT = 5;
+  COMPAREANDSET = 6;
 
   // Coordinator State Machine Operator
   META_WRITE = 2000;
@@ -48,6 +49,17 @@ message PutIfAbsentRequest {
 }
 
 message PutIfAbsentResponse {
+  repeated bytes put_keys = 1;
+}
+
+message CompareAndSetRequest {
+  string cf_name = 1;
+  repeated dingodb.pb.common.KeyValue kvs = 2;
+  repeated bytes expect_values = 3;
+  bool is_atomic = 4;
+}
+
+message CompareAndSetResponse {
   repeated bytes put_keys = 1;
 }
 
@@ -94,6 +106,7 @@ message Request {
     DeleteRangeRequest delete_range = 1002;
     DeleteBatchRequest delete_batch = 1003;
     SplitRequest split = 1004;
+    CompareAndSetRequest compare_and_set = 1005;
 
     // Coordinator Operation[2000, 3000]
     RaftMetaRequest meta_req = 2000;
@@ -109,6 +122,7 @@ message Response {
     DeleteRangeResponse delete_range = 1002;
     DeleteBatchResponse delete_batch = 1003;
     SplitResponse split = 1004;
+    CompareAndSetResponse compare_and_set = 1005;
 
     RaftCreateSchemaResponse create_schema_req = 2001;
     RaftCreateTableResponse create_table_req = 2002;

--- a/proto/store.proto
+++ b/proto/store.proto
@@ -143,6 +143,35 @@ message KvDeleteRangeResponse {
   uint64 delete_count = 2;
 }
 
+message KvCompareAndSetRequest {
+  uint64 region_id = 1;
+  dingodb.pb.common.KeyValue kv = 2;
+  // empty means key not exist
+  bytes expect_value = 3;
+}
+
+message KvCompareAndSetResponse {
+  dingodb.pb.error.Error error = 1;
+  // key_state = true, update success
+  // key_state = false, update failed
+  bool key_state = 2;
+}
+
+message KvBatchCompareAndSetRequest {
+  uint64 region_id = 1;
+  repeated dingodb.pb.common.KeyValue kvs = 2;
+  // empty means key not exist
+  repeated bytes expect_values = 3;
+  bool is_atomic = 4;
+}
+
+message KvBatchCompareAndSetResponse {
+  dingodb.pb.error.Error error = 1;
+  // key_state = true, update success
+  // key_state = false, update failed
+  repeated bool key_states = 2;
+}
+
 // aggregation type
 enum AggregationType {
   AGGREGATION_NONE = 0;
@@ -360,6 +389,8 @@ service StoreService {
   rpc KvBatchPutIfAbsent(KvBatchPutIfAbsentRequest) returns (KvBatchPutIfAbsentResponse);
   rpc KvBatchDelete(KvBatchDeleteRequest) returns (KvBatchDeleteResponse);
   rpc KvDeleteRange(KvDeleteRangeRequest) returns (KvDeleteRangeResponse);
+  rpc KvCompareAndSet(KvCompareAndSetRequest) returns (KvCompareAndSetResponse);
+  rpc KvBatchCompareAndSet(KvBatchCompareAndSetRequest) returns (KvBatchCompareAndSetResponse);
 
   rpc KvScanBegin(KvScanBeginRequest) returns (KvScanBeginResponse);
   rpc KvScanContinue(KvScanContinueRequest) returns (KvScanContinueResponse);

--- a/src/client/store_client.cc
+++ b/src/client/store_client.cc
@@ -163,6 +163,10 @@ void Sender(client::ServerInteractionPtr interaction, const std::string& method,
       client::SendKvDeleteRange(interaction, FLAGS_region_id, FLAGS_prefix);
     } else if (method == "KvScan") {
       client::SendKvScan(interaction, FLAGS_region_id, FLAGS_prefix);
+    } else if (method == "KvCompareAndSet") {
+      client::SendKvCompareAndSet(interaction, FLAGS_region_id, FLAGS_key);
+    } else if (method == "KvBatchCompareAndSet") {
+      client::SendKvBatchCompareAndSet(interaction, FLAGS_region_id, FLAGS_prefix, 100);
     }
 
     // Test

--- a/src/client/store_client_function.cc
+++ b/src/client/store_client_function.cc
@@ -170,6 +170,41 @@ void SendKvScan(ServerInteractionPtr interaction, uint64_t region_id, const std:
   interaction->SendRequest("StoreService", "KvScanRelease", release_request, release_response);
 }
 
+void SendKvCompareAndSet(ServerInteractionPtr interaction, uint64_t region_id, const std::string& key) {
+  dingodb::pb::store::KvCompareAndSetRequest request;
+  dingodb::pb::store::KvCompareAndSetResponse response;
+
+  request.set_region_id(region_id);
+  dingodb::pb::common::KeyValue* kv = request.mutable_kv();
+  kv->set_key(key);
+  kv->set_value(Helper::GenRandomString(64));
+  request.set_expect_value("");
+
+  interaction->SendRequest("StoreService", "KvCompareAndSet", request, response);
+}
+
+void SendKvBatchCompareAndSet(ServerInteractionPtr interaction, uint64_t region_id, const std::string& prefix,
+                              int count) {
+  dingodb::pb::store::KvBatchCompareAndSetRequest request;
+  dingodb::pb::store::KvBatchCompareAndSetResponse response;
+
+  request.set_region_id(region_id);
+  for (int i = 0; i < count; ++i) {
+    std::string key = prefix + Helper::GenRandomString(30);
+    auto* kv = request.add_kvs();
+    kv->set_key(key);
+    kv->set_value(Helper::GenRandomString(64));
+  }
+
+  for (int i = 0; i < count; i++) {
+    request.add_expect_values("");
+  }
+
+  request.set_is_atomic(false);
+
+  interaction->SendRequest("StoreService", "KvBatchCompareAndSet", request, response);
+}
+
 dingodb::pb::common::RegionDefinition BuildRegionDefinition(uint64_t region_id, const std::string& raft_group,
                                                             std::vector<std::string>& raft_addrs,
                                                             const std::string& start_key, const std::string& end_key) {

--- a/src/client/store_client_function.h
+++ b/src/client/store_client_function.h
@@ -52,6 +52,8 @@ void SendKvBatchPutIfAbsent(ServerInteractionPtr interaction, uint64_t region_id
 void SendKvBatchDelete(ServerInteractionPtr interaction, uint64_t region_id, const std::string& key);
 void SendKvDeleteRange(ServerInteractionPtr interaction, uint64_t region_id, const std::string& prefix);
 void SendKvScan(ServerInteractionPtr interaction, uint64_t region_id, const std::string& prefix);
+void SendKvCompareAndSet(ServerInteractionPtr interaction, uint64_t region_id, const std::string& key);
+void SendKvBatchCompareAndSet(ServerInteractionPtr interaction, uint64_t region_id, const std::string& prefix, int count);
 
 // region
 void SendAddRegion(ServerInteractionPtr interaction, uint64_t region_id, const std::string& raft_group,

--- a/src/engine/raw_engine.h
+++ b/src/engine/raw_engine.h
@@ -99,6 +99,15 @@ class RawEngine {
 
     virtual butil::Status KvCompareAndSet(const pb::common::KeyValue& kv, const std::string& value,
                                           bool& key_state) = 0;
+    // Batch implementation comparisons and settings.
+    // There are three layers of semantics:
+    // 1. If key not exists, set key=value
+    // 2. If key exists, and value in request is null, delete key
+    // 3. If key exists, set key=value
+    // Not available internally, only for RPC use
+    virtual butil::Status KvBatchCompareAndSet(const std::vector<pb::common::KeyValue>& kvs,
+                                               const std::vector<std::string>& expect_values, std::vector<bool>& key_states,
+                                               bool is_atomic) = 0;
 
     virtual butil::Status KvDelete(const std::string& key) = 0;
     virtual butil::Status KvBatchDelete(const std::vector<std::string>& keys) = 0;

--- a/src/engine/raw_rocks_engine.h
+++ b/src/engine/raw_rocks_engine.h
@@ -201,6 +201,16 @@ class RawRocksEngine : public RawEngine {
     // key must be exist
     butil::Status KvCompareAndSet(const pb::common::KeyValue& kv, const std::string& value, bool& key_state) override;
 
+    // Batch implementation comparisons and settings.
+    // There are three layers of semantics:
+    // 1. If key not exists, set key=value
+    // 2. If key exists, and value in request is null, delete key
+    // 3. If key exists, set key=value
+    // Not available internally, only for RPC use
+    butil::Status KvBatchCompareAndSet(const std::vector<pb::common::KeyValue>& kvs,
+                                       const std::vector<std::string>& expect_values, std::vector<bool>& key_states,
+                                       bool is_atomic) override;
+
     butil::Status KvDelete(const std::string& key) override;
     butil::Status KvBatchDelete(const std::vector<std::string>& keys) override;
 

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -47,6 +47,9 @@ class Storage {
 
   butil::Status KvDeleteRange(std::shared_ptr<Context> ctx, const pb::common::Range& range);
 
+  butil::Status KvCompareAndSet(std::shared_ptr<Context> ctx, const std::vector<pb::common::KeyValue>& kvs,
+                                const std::vector<std::string>& expect_values, bool is_atomic);
+
   butil::Status KvScanBegin([[maybe_unused]] std::shared_ptr<Context> ctx, const std::string& cf_name,
                             uint64_t region_id, const pb::common::Range& range, uint64_t max_fetch_cnt, bool key_only,
                             bool disable_auto_release, bool disable_coprocessor,

--- a/src/handler/handler.h
+++ b/src/handler/handler.h
@@ -34,6 +34,7 @@ enum class HandlerType {
   kDeleteBatch = pb::raft::DELETEBATCH,
   kSplit = pb::raft::SPLIT,
   kMetaWrite = pb::raft::META_WRITE,
+  kCompareAndSet = pb::raft::COMPAREANDSET,
 
   // Snapshot
   kSaveSnapshot = 1000,

--- a/src/handler/raft_handler.h
+++ b/src/handler/raft_handler.h
@@ -39,6 +39,14 @@ class PutIfAbsentHandler : public BaseHandler {
               const pb::raft::Request &req, store::RegionMetricsPtr region_metrics) override;
 };
 
+// CompareAndSetRequest
+class CompareAndSetHandler : public BaseHandler {
+ public:
+  HandlerType GetType() override { return HandlerType::kCompareAndSet; }
+  void Handle(std::shared_ptr<Context> ctx, store::RegionPtr region, std::shared_ptr<RawEngine> engine,
+              const pb::raft::Request &req, store::RegionMetricsPtr region_metrics) override;
+};
+
 // DeleteRangeRequest
 class DeleteRangeHandler : public BaseHandler {
  public:

--- a/src/server/store_service.h
+++ b/src/server/store_service.h
@@ -63,6 +63,14 @@ class StoreServiceImpl : public pb::store::StoreService {
   void KvDeleteRange(google::protobuf::RpcController* controller, const pb::store::KvDeleteRangeRequest* request,
                      pb::store::KvDeleteRangeResponse* response, google::protobuf::Closure* done) override;
 
+  void KvCompareAndSet(google::protobuf::RpcController* controller, const pb::store::KvCompareAndSetRequest* request,
+                       pb::store::KvCompareAndSetResponse* response, google::protobuf::Closure* done) override;
+
+  void KvBatchCompareAndSet(google::protobuf::RpcController* controller,
+                            const pb::store::KvBatchCompareAndSetRequest* request,
+                            pb::store::KvBatchCompareAndSetResponse* response,
+                            google::protobuf::Closure* done) override;
+
   void KvScanBegin(google::protobuf::RpcController* controller, const ::dingodb::pb::store::KvScanBeginRequest* request,
                    ::dingodb::pb::store::KvScanBeginResponse* response, ::google::protobuf::Closure* done) override;
 


### PR DESCRIPTION
    Batch implementation comparisons and settings.
    There are three layers of semantics:
    1. If the key does not exist, set kv.
    2. The key exists and can be deleted.
    3. The key exists to update the value.
    Not available internally, only for RPC use.