### PR TITLE
[fix][index] Fix VectorScanQuery and GetBorderId for prev scan.

### DIFF
--- a/src/vector/vector_reader.h
+++ b/src/vector/vector_reader.h
@@ -51,6 +51,8 @@ class VectorReader {
                                        VectorIndexWrapperPtr vector_index,
                                        pb::common::VectorIndexMetrics& region_metrics);
 
+  butil::Status GetVectorCount(const pb::common::Range& region_range, uint64_t& vector_count);
+
   // This function is for testing only
   butil::Status VectorBatchSearchDebug(std::shared_ptr<Engine::VectorReader::Context> ctx,
                                        std::vector<pb::index::VectorWithDistanceResult>& results,


### PR DESCRIPTION
[fix][index] Use accurate vector count for VectorGetRegionMetrics.
[fix][index] Fix VectorScanQuery and GetBorderId for prev scan.