### PR TITLE
[fix][coordinator] SplitRegion add STORE_REGION_CHECK to prevent

### DIFF
--- a/src/coordinator/coordinator_control.h
+++ b/src/coordinator/coordinator_control.h
@@ -706,6 +706,7 @@ class CoordinatorControl : public MetaControl {
                            uint64_t split_to_region_id, const std::string &water_shed_key, bool store_create_region);
   static void AddCheckVectorIndexTask(pb::coordinator::TaskList *task_list, uint64_t store_id, uint64_t region_id);
   static void AddLoadVectorIndexTask(pb::coordinator::TaskList *task_list, uint64_t store_id, uint64_t region_id);
+  static void AddCheckStoreRegionTask(pb::coordinator::TaskList *task_list, uint64_t store_id, uint64_t region_id);
 
   static void GenDeleteRegionStoreOperation(pb::coordinator::StoreOperation &store_operation, uint64_t store_id,
                                             uint64_t region_id);


### PR DESCRIPTION
[fix][coordinator] SplitRegion add STORE_REGION_CHECK to prevent confilct CreateRegion and SplitRegion.

Improve send store_operation performance for not delete region operations.