### PR TITLE
[fix] fix follower update regionmap

### DIFF
--- a/src/coordinator/coordinator_control.h
+++ b/src/coordinator/coordinator_control.h
@@ -704,6 +704,7 @@ class CoordinatorControl : public MetaControl {
                            uint64_t merge_to_region_id);
   static void AddSplitTask(pb::coordinator::TaskList *task_list, uint64_t store_id, uint64_t region_id,
                            uint64_t split_to_region_id, const std::string &water_shed_key, bool store_create_region);
+  static void AddCheckSplitResultTask(pb::coordinator::TaskList *task_list, uint64_t split_to_region_id);
   static void AddCheckVectorIndexTask(pb::coordinator::TaskList *task_list, uint64_t store_id, uint64_t region_id);
   static void AddLoadVectorIndexTask(pb::coordinator::TaskList *task_list, uint64_t store_id, uint64_t region_id);
   static void AddCheckStoreRegionTask(pb::coordinator::TaskList *task_list, uint64_t store_id, uint64_t region_id);

--- a/src/coordinator/coordinator_control_coor.cc
+++ b/src/coordinator/coordinator_control_coor.cc
@@ -3529,10 +3529,10 @@ void CoordinatorControl::UpdateRegionMapAndStoreOperation(const pb::common::Stor
     };
 
     if (region_metrics_is_not_leader) {
-      if (region_to_update.state() != pb::common::RegionState::REGION_DELETE &&
+      if ((!need_update_region_definition) && region_to_update.state() != pb::common::RegionState::REGION_DELETE &&
           region_to_update.state() != pb::common::RegionState::REGION_DELETING &&
           region_to_update.state() != pb::common::RegionState::REGION_DELETED) {
-        DINGO_LOG(DEBUG) << "region is not deleted, follower can't update "
+        DINGO_LOG(DEBUG) << "region is not deleted and need_update_region_definition is false, follower can't update "
                             "region_map, store_id="
                          << store_metrics.id() << " region_id = " << region_metrics.id();
         continue;

--- a/src/metrics/dingo_bvar.h
+++ b/src/metrics/dingo_bvar.h
@@ -139,8 +139,8 @@ inline DingoMultiDimension<T>::DingoMultiDimension(const butil::StringPiece& pre
 
 template <typename T>
 DingoMultiDimension<T>::~DingoMultiDimension() {
-  delete_stats();
   hide();
+  delete_stats();
 }
 
 template <typename T>


### PR DESCRIPTION
[fix][coordinator] Add AddCheckSplitResultTask before clean split task list to make split more serializable.
[fix][common] Fix DingoMultiDimension coredump in destruct function.
[fix][coordinator] Fix follower can't update region map.