### PR TITLE
[feat][index] Use wq to do vector add, search and delete.

### DIFF
--- a/conf/index.template.yaml
+++ b/conf/index.template.yaml
@@ -9,7 +9,7 @@ server:
   metrics_collect_interval_s: 300
   scrub_vector_index_interval_s: 60
   # worker_thread_num: 10 # must >4, worker_thread_num priority worker_thread_ratio
-  worker_thread_ratio: 1 # cpu core * ratio
+  worker_thread_ratio: 2 # cpu core * ratio
 region:
   region_max_size: 134217728 # 128M
   enable_auto_split: true

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -96,8 +96,11 @@ class Storage {
 
   butil::Status ValidateLeader(int64_t region_id);
 
+  bool Execute(int64_t region_id, TaskRunnablePtr task);
+
  private:
   std::shared_ptr<Engine> engine_;
+  std::vector<WorkerPtr> workers_;  // this is for long-time request processing, for instance VectorBatchSearch
 };
 
 }  // namespace dingodb


### PR DESCRIPTION
VectorAdd, VectorSearch and VectorDelete use parallel threads or omp to speed up the vector index operations, and the batch op also may depelete the brpc bthreads for rpc processing when there is many many index regions in a index process. So we use wq to limit the concurrent threads count of these operations and use isolated bthreads to protect the rpc processing to proceed.