### PR TITLE
[fix][store] Add optimize scan performance macro. default disable scan  performance macro.

### DIFF
--- a/src/scan/scan.h
+++ b/src/scan/scan.h
@@ -32,6 +32,13 @@
 
 namespace dingodb {
 
+// enable scan optimization switch to speed up scan execution if enabled
+#ifndef ENABLE_SCAN_OPTIMIZATION
+#define ENABLE_SCAN_OPTIMIZATION
+#endif
+
+#undef ENABLE_SCAN_OPTIMIZATION
+
 enum class ScanState : unsigned char {
   kUninit = 0,
   kOpening = 1,
@@ -79,11 +86,11 @@ class ScanContext {
   void Close();
   static std::chrono::milliseconds GetCurrentTime();
   butil::Status GetKeyValue(std::vector<pb::common::KeyValue>& kvs);  // NOLINT
-
+#if defined(ENABLE_SCAN_OPTIMIZATION)
   butil::Status AsyncWork();
   void WaitForReady();
   butil::Status SeekCheck();
-
+#endif
   std::string scan_id_;
 
   int64_t region_id_;
@@ -111,7 +118,7 @@ class ScanContext {
   std::chrono::milliseconds last_time_ms_;
 
   bthread_mutex_t mutex_;
-
+#if defined(ENABLE_SCAN_OPTIMIZATION)
   enum class SeekState : unsigned char {
     kUninit = 0,
     kInitting = 1,
@@ -122,6 +129,7 @@ class ScanContext {
 
   // default = kUninit
   volatile SeekState seek_state_;
+#endif
 
   bool disable_coprocessor_;
 


### PR DESCRIPTION
 [fix][store] Add optimize scan performance macro. default disable scan  performance macro.
        1. use the swich maybe consumes the number of available threads in the process.