### PR TITLE
[fix][dingo-sdk] Correct the position of regionType and regionState in the returned region

### DIFF
--- a/java/dingo-sdk/src/main/java/io/dingodb/sdk/service/cluster/ClusterServiceClient.java
+++ b/java/dingo-sdk/src/main/java/io/dingodb/sdk/service/cluster/ClusterServiceClient.java
@@ -103,7 +103,7 @@ public class ClusterServiceClient {
           int regionState = region.getStateValue();
           long createTime = region.getCreateTimestamp();
           long deleteTime = region.getDeletedTimestamp();
-          return new InternalRegion(regionType, regionState, createTime, deleteTime, followers);
+          return new InternalRegion(regionState, regionType, createTime, deleteTime, followers);
     }
 
 }


### PR DESCRIPTION
Correct the position of regionType and regionState in the returned region