### PR TITLE
[fix][coordinator] Fix coordinator cannot re-route region_cmd when raft

### DIFF
--- a/proto/coordinator.proto
+++ b/proto/coordinator.proto
@@ -186,6 +186,7 @@ message RegionCmd {
   int64 region_id = 3;                // this is region id
   RegionCmdType region_cmd_type = 4;  // the cmd want to be executed
   int64 create_timestamp = 5;         // the timestamp when this cmd is created
+  int64 store_id = 6;                 // the store id of this cmd
   oneof Request {
     CreateRequest create_request = 11;           // create parameters
     DeleteRequest delete_request = 12;           // delete parameters

--- a/proto/coordinator_internal.proto
+++ b/proto/coordinator_internal.proto
@@ -171,6 +171,7 @@ enum MetaIncrementOpType {
   CREATE = 0;
   UPDATE = 1;
   DELETE = 2;
+  MODIFY = 3;  // this is for modify operation, defined by each type
 }
 
 message MetaIncrementCoordinator {
@@ -263,9 +264,19 @@ message MetaIncrementIdEpoch {
 }
 
 message MetaIncrementStoreOperation {
+  message MoveRegionCmd {
+    int64 region_cmd_id = 1;
+    int64 from_store_id = 2;
+    int64 to_store_id = 3;
+  }
+
   int64 id = 1;  // this is store id
   StoreOperationInternal store_operation = 2;
   MetaIncrementOpType op_type = 3;
+
+  oneof Modify {
+    MoveRegionCmd move_region_cmd = 4;
+  }
 }
 
 message MetaIncrementRegionCmd {

--- a/src/coordinator/coordinator_control.h
+++ b/src/coordinator/coordinator_control.h
@@ -514,6 +514,10 @@ class CoordinatorControl : public MetaControl {
 
   butil::Status AddStoreOperation(const pb::coordinator::StoreOperation &store_operation, bool check_conflict,
                                   pb::coordinator_internal::MetaIncrement &meta_increment);
+  // MoveRegionCmd
+  // move region_cmd from one store to another store
+  butil::Status MoveRegionCmd(int64_t old_store_id, int64_t new_store_id, int64_t region_cmd_id,
+                              pb::coordinator_internal::MetaIncrement &meta_increment);
   butil::Status AddRegionCmd(int64_t store_id, int64_t job_id, const pb::coordinator::RegionCmd &region_cmd,
                              pb::coordinator_internal::MetaIncrement &meta_increment);
   butil::Status UpdateRegionCmd(int64_t store_id, const pb::coordinator::RegionCmd &region_cmd,


### PR DESCRIPTION
[fix][coordinator] Fix coordinator cannot re-route region_cmd when raft not leader is detected.