### PR TITLE
[feat][store] Implement min_commit_ts logic to reduce read-write

### DIFF
--- a/proto/store.proto
+++ b/proto/store.proto
@@ -32,6 +32,9 @@ message Context {
   int64 region_id = 1;
   dingodb.pb.common.RegionEpoch region_epoch = 2;
   IsolationLevel isolation_level = 3;
+  // Read requests should ignore locks belonging to these transactions because either
+  // these transactions are rolled back or theirs min_commit_ts > read request's start_ts.
+  repeated uint64 resolved_locks = 4;
 }
 
 message KvGetRequest {
@@ -400,16 +403,17 @@ enum Action {
 }
 
 message LockInfo {
-  bytes primary_lock = 1;   // the primary lock of the transaction
-  bytes key = 2;            // the key of the lock
-  int64 lock_ts = 3;        // the start_ts of the transaction
-  int64 for_update_ts = 4;  // the for_update_ts of the pessimistic lock
-  int64 lock_ttl = 5;       // the lock ttl timestamp in milisecond
-  int64 txn_size = 6;       // the number of keys involved in the transaction
-  Op lock_type = 7;         // the type of the lock, it can be put, delete, lock
-  bytes short_value = 8;    // the short value will persist to lock_info, and do not write data, commit will set it to
-                            // write_info.short_value
-  bytes extra_data = 9;     // the extra_data executor want to store in lock
+  bytes primary_lock = 1;    // the primary lock of the transaction
+  bytes key = 2;             // the key of the lock
+  int64 lock_ts = 3;         // the start_ts of the transaction
+  int64 for_update_ts = 4;   // the for_update_ts of the pessimistic lock
+  int64 lock_ttl = 5;        // the lock ttl timestamp in milisecond
+  int64 txn_size = 6;        // the number of keys involved in the transaction
+  Op lock_type = 7;          // the type of the lock, it can be put, delete, lock
+  bytes short_value = 8;     // the short value will persist to lock_info, and do not write data, commit will set it to
+                             // write_info.short_value
+  bytes extra_data = 9;      // the extra_data executor want to store in lock
+  int64 min_commit_ts = 10;  // the min_commit_ts of the transaction
 }
 
 message WriteInfo {
@@ -488,6 +492,13 @@ message AlreadyExist {
   bytes key = 1;
 }
 
+message CommitTsExpired {
+  int64 start_ts = 1;
+  int64 attempted_commit_ts = 2;
+  bytes key = 3;
+  int64 min_commit_ts = 4;
+}
+
 message TxnResultInfo {
   // Client should backoff or cleanup the lock then retry, this error occurs in get phase.
   LockInfo locked = 1;
@@ -497,6 +508,8 @@ message TxnResultInfo {
   TxnNotFound txn_not_found = 3;
   // CheckTxnStatus is sent to a lock that's not the primary.
   PrimaryMismatch primary_mismatch = 4;
+  // Commit ts is earlier than min commit ts of a transaction.
+  CommitTsExpired commit_ts_expired = 5;
 }
 
 // TxnGet do point-lookup a value for key in the transaction with start_ts
@@ -747,6 +760,9 @@ message TxnCheckTxnStatusRequest {
   // Starting timestamp oracle of the transaction being checked.
   int64 lock_ts = 4;
   // The start timestamp oracle of the transaction which this request is part of.
+  // If the the lock_ts < caller_start_ts and the lock_ttl is not outdated, the transaction is not expired.
+  // In this case, store will try to update the lock's min_commit_ts to caller_start_ts, in order to prevent the
+  // read-write conflict. If the min_commit_ts is updated, the Action of the response will be MinCommitTSPushed.
   int64 caller_start_ts = 5;
   // The client must specify the current time to dingo-store using this timestamp oracle.
   // It is used to check TTL timeouts. It may be inaccurate.
@@ -770,6 +786,7 @@ message TxnCheckTxnStatusResponse {
   // if the transaction of the lock is committed, the commit_ts is returned
   int64 commit_ts = 5;
   // The action performed by dingo-store (and why if the action is to rollback).
+  // If the min_commit_ts of the lock is pushed, the Action of the response will be MinCommitTSPushed.
   Action action = 6;
   LockInfo lock_info = 7;
 }

--- a/src/client/store_client_function_txn.cc
+++ b/src/client/store_client_function_txn.cc
@@ -51,6 +51,7 @@ DECLARE_string(start_key);
 DECLARE_string(end_key);
 DECLARE_int64(vector_id);
 DEFINE_int64(start_ts, 0, "start_ts");
+DEFINE_int64(resolve_locks, 0, "resolve_locks");
 DEFINE_int64(end_ts, 0, "end_ts");
 DEFINE_int64(commit_ts, 0, "start_ts");
 DEFINE_int64(lock_ts, 0, "start_ts");
@@ -534,6 +535,10 @@ void SendTxnGet(int64_t region_id) {
   }
   request.set_start_ts(FLAGS_start_ts);
 
+  if (FLAGS_resolve_locks > 0) {
+    request.mutable_context()->add_resolved_locks(FLAGS_resolve_locks);
+  }
+
   DINGO_LOG(INFO) << "Request: " << request.DebugString();
 
   InteractionManager::GetInstance().SendRequestWithContext(service_name, "TxnGet", request, response);
@@ -600,6 +605,10 @@ void SendTxnScan(int64_t region_id) {
 
   request.set_is_reverse(FLAGS_is_reverse);
   request.set_key_only(FLAGS_key_only);
+
+  if (FLAGS_resolve_locks > 0) {
+    request.mutable_context()->add_resolved_locks(FLAGS_resolve_locks);
+  }
 
   DINGO_LOG(INFO) << "Request: " << request.DebugString();
 
@@ -984,6 +993,10 @@ void SendTxnBatchGet(int64_t region_id) {
     return;
   }
   request.set_start_ts(FLAGS_start_ts);
+
+  if (FLAGS_resolve_locks > 0) {
+    request.mutable_context()->add_resolved_locks(FLAGS_resolve_locks);
+  }
 
   DINGO_LOG(INFO) << "Request: " << request.DebugString();
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -157,12 +157,14 @@ class Engine : public std::enable_shared_from_this<Engine> {
 
     virtual butil::Status TxnBatchGet(std::shared_ptr<Context> ctx, int64_t start_ts,
                                       const std::vector<std::string>& keys, std::vector<pb::common::KeyValue>& kvs,
+                                      const std::set<int64_t>& resolved_locks,
                                       pb::store::TxnResultInfo& txn_result_info) = 0;
     virtual butil::Status TxnScan(std::shared_ptr<Context> ctx, int64_t start_ts, const pb::common::Range& range,
                                   int64_t limit, bool key_only, bool is_reverse,
+                                  const std::set<int64_t>& resolved_locks, bool disable_coprocessor,
+                                  const pb::common::CoprocessorV2& coprocessor,
                                   pb::store::TxnResultInfo& txn_result_info, std::vector<pb::common::KeyValue>& kvs,
-                                  bool& has_more, std::string& end_key, bool disable_coprocessor,
-                                  const pb::common::CoprocessorV2& coprocessor) = 0;
+                                  bool& has_more, std::string& end_key) = 0;
     virtual butil::Status TxnScanLock(std::shared_ptr<Context> ctx, int64_t min_lock_ts, int64_t max_lock_ts,
                                       const pb::common::Range& range, int64_t limit,
                                       std::vector<pb::store::LockInfo>& lock_infos) = 0;

--- a/src/engine/raft_store_engine.cc
+++ b/src/engine/raft_store_engine.cc
@@ -513,18 +513,20 @@ std::shared_ptr<Engine::TxnReader> RaftStoreEngine::NewTxnReader(pb::common::Raw
 butil::Status RaftStoreEngine::TxnReader::TxnBatchGet(std::shared_ptr<Context> ctx, int64_t start_ts,
                                                       const std::vector<std::string>& keys,
                                                       std::vector<pb::common::KeyValue>& kvs,
+                                                      const std::set<int64_t>& resolved_locks,
                                                       pb::store::TxnResultInfo& txn_result_info) {
-  return TxnEngineHelper::BatchGet(txn_reader_raw_engine_, ctx->IsolationLevel(), start_ts, keys, kvs, txn_result_info);
+  return TxnEngineHelper::BatchGet(txn_reader_raw_engine_, ctx->IsolationLevel(), start_ts, keys, resolved_locks,
+                                   txn_result_info, kvs);
 }
 
-butil::Status RaftStoreEngine::TxnReader::TxnScan(std::shared_ptr<Context> ctx, int64_t start_ts,
-                                                  const pb::common::Range& range, int64_t limit, bool key_only,
-                                                  bool is_reverse, pb::store::TxnResultInfo& txn_result_info,
-                                                  std::vector<pb::common::KeyValue>& kvs, bool& has_more,
-                                                  std::string& end_key, bool disable_coprocessor,
-                                                  const pb::common::CoprocessorV2& coprocessor) {
+butil::Status RaftStoreEngine::TxnReader::TxnScan(
+    std::shared_ptr<Context> ctx, int64_t start_ts, const pb::common::Range& range, int64_t limit, bool key_only,
+    bool is_reverse, const std::set<int64_t>& resolved_locks, bool disable_coprocessor,
+    const pb::common::CoprocessorV2& coprocessor, pb::store::TxnResultInfo& txn_result_info,
+    std::vector<pb::common::KeyValue>& kvs, bool& has_more, std::string& end_key) {
   return TxnEngineHelper::Scan(txn_reader_raw_engine_, ctx->IsolationLevel(), start_ts, range, limit, key_only,
-                               is_reverse, txn_result_info, kvs, has_more, end_key, disable_coprocessor, coprocessor);
+                               is_reverse, resolved_locks, disable_coprocessor, coprocessor, txn_result_info, kvs,
+                               has_more, end_key);
 }
 
 butil::Status RaftStoreEngine::TxnReader::TxnScanLock(std::shared_ptr<Context> /*ctx*/, int64_t min_lock_ts,

--- a/src/engine/raft_store_engine.h
+++ b/src/engine/raft_store_engine.h
@@ -175,12 +175,13 @@ class RaftStoreEngine : public Engine, public RaftControlAble {
     TxnReader(std::shared_ptr<RawEngine> engine) : txn_reader_raw_engine_(engine) {}
 
     butil::Status TxnBatchGet(std::shared_ptr<Context> ctx, int64_t start_ts, const std::vector<std::string>& keys,
-                              std::vector<pb::common::KeyValue>& kvs,
+                              std::vector<pb::common::KeyValue>& kvs, const std::set<int64_t>& resolved_locks,
                               pb::store::TxnResultInfo& txn_result_info) override;
     butil::Status TxnScan(std::shared_ptr<Context> ctx, int64_t start_ts, const pb::common::Range& range, int64_t limit,
-                          bool key_only, bool is_reverse, pb::store::TxnResultInfo& txn_result_info,
-                          std::vector<pb::common::KeyValue>& kvs, bool& has_more, std::string& end_key,
-                          bool disable_coprocessor, const pb::common::CoprocessorV2& coprocessor) override;
+                          bool key_only, bool is_reverse, const std::set<int64_t>& resolved_locks,
+                          bool disable_coprocessor, const pb::common::CoprocessorV2& coprocessor,
+                          pb::store::TxnResultInfo& txn_result_info, std::vector<pb::common::KeyValue>& kvs,
+                          bool& has_more, std::string& end_key) override;
     butil::Status TxnScanLock(std::shared_ptr<Context> ctx, int64_t min_lock_ts, int64_t max_lock_ts,
                               const pb::common::Range& range, int64_t limit,
                               std::vector<pb::store::LockInfo>& lock_infos) override;

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -84,11 +84,13 @@ class Storage {
 
   // txn reader
   butil::Status TxnBatchGet(std::shared_ptr<Context> ctx, int64_t start_ts, const std::vector<std::string>& keys,
-                            pb::store::TxnResultInfo& txn_result_info, std::vector<pb::common::KeyValue>& kvs);
+                            const std::set<int64_t>& resolved_locks, pb::store::TxnResultInfo& txn_result_info,
+                            std::vector<pb::common::KeyValue>& kvs);
   butil::Status TxnScan(std::shared_ptr<Context> ctx, int64_t start_ts, const pb::common::Range& range, int64_t limit,
-                        bool key_only, bool is_reverse, pb::store::TxnResultInfo& txn_result_info,
-                        std::vector<pb::common::KeyValue>& kvs, bool& has_more, std::string& end_key,
-                        bool disable_coprocessor, const pb::common::CoprocessorV2& coprocessor);
+                        bool key_only, bool is_reverse, const std::set<int64_t>& resolved_locks,
+                        pb::store::TxnResultInfo& txn_result_info, std::vector<pb::common::KeyValue>& kvs,
+                        bool& has_more, std::string& end_key, bool disable_coprocessor,
+                        const pb::common::CoprocessorV2& coprocessor);
   butil::Status TxnScanLock(std::shared_ptr<Context> ctx, int64_t max_ts, const std::string& start_key, int64_t limit,
                             const std::string& end_key, pb::store::TxnResultInfo& txn_result_info,
                             std::vector<pb::store::LockInfo>& lock_infos);


### PR DESCRIPTION
[feat][store] Implement min_commit_ts logic to reduce read-write conflict.

The min_commit_ts works in TxnGet, TxnScan, TxnCheckTxnStatus and TxnCommit. It is used to reduct the read-write conflict.