### PR TITLE
[fix] Fix region_service coredump.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,11 +565,19 @@ execute_process(
 
 if (NOT GIT_VERSION)
     set(GIT_VERSION "unknown")
+    message(WARNING "Git version is unknown")
 endif()
 
 if (NOT GIT_TAG_NAME)
     set(GIT_TAG_NAME "unknown")
+    message(WARNING "Git tag name is unknown")
 endif()
+
+message(STATUS "Git version: ${GIT_VERSION}")
+message(STATUS "Git tag name: ${GIT_TAG_NAME}")
+message(STATUS "Git commit user: ${GIT_COMMIT_USER}")
+message(STATUS "Git commit mail: ${GIT_COMMIT_MAIL}")
+message(STATUS "Git commit time: ${GIT_COMMIT_TIME}")
 
 add_definitions(-DGLOG_CUSTOM_PREFIX_SUPPORT=ON)
 add_definitions(-DGIT_VERSION="${GIT_VERSION}")

--- a/src/common/runnable.cc
+++ b/src/common/runnable.cc
@@ -300,10 +300,10 @@ SimpleWorkerSet::SimpleWorkerSet(std::string name, uint32_t worker_num, int64_t 
       use_pthread_(use_pthread),
       use_prior_(use_prior),
       max_pending_task_count_(max_pending_task_count),
-      total_task_count_metrics_(fmt::format("dingo_prior_worker_set_{}_total_task_count", name)),
-      pending_task_count_metrics_(fmt::format("dingo_prior_worker_set_{}_pending_task_count", name)),
-      queue_wait_metrics_(fmt::format("dingo_prior_worker_set_{}_queue_wait_latency", name)),
-      queue_run_metrics_(fmt::format("dingo_prior_worker_set_{}_queue_run_latency", name)) {
+      total_task_count_metrics_(fmt::format("dingo_simple_worker_set_{}_total_task_count", name)),
+      pending_task_count_metrics_(fmt::format("dingo_simple_worker_set_{}_pending_task_count", name)),
+      queue_wait_metrics_(fmt::format("dingo_simple_worker_set_{}_queue_wait_latency", name)),
+      queue_run_metrics_(fmt::format("dingo_simple_worker_set_{}_queue_run_latency", name)) {
   bthread_mutex_init(&mutex_, nullptr);
   bthread_cond_init(&cond_, nullptr);
 }

--- a/src/server/region_service.cc
+++ b/src/server/region_service.cc
@@ -283,7 +283,8 @@ void RegionImpl::PrintRegions(std::ostream& os, bool use_html) {
 
     std::string start_key = Helper::StringToHex(region.definition().range().start_key());
     std::string end_key = Helper::StringToHex(region.definition().range().end_key());
-    if (region.region_type() == pb::common::INDEX_REGION) {
+    if (region.region_type() == pb::common::INDEX_REGION &&
+        region.definition().index_parameter().has_vector_index_parameter()) {
       int64_t min_vector_id = 0, max_vector_id = 0;
       VectorCodec::DecodeRangeToVectorId(region.definition().range(), min_vector_id, max_vector_id);
       start_key += fmt::format("({})", min_vector_id);


### PR DESCRIPTION
Fix region_service coredump when a region is index by not a vector region.
Fix brpc hang up when deleting many regions. Because DeleteRange in BDB is very heavy, to many execq do delete_range will cause dead_lock and all brpc threads cpu 100%.