### PR TITLE
[fix][index] Fix the crash problem caused by insufficient aio nr. At present, it is found that aio nr is insufficient. It only reports an error and no longer crashes.

### DIFF
--- a/src/diskann/diskann_core.h
+++ b/src/diskann/diskann_core.h
@@ -97,6 +97,7 @@ class DiskANNCore {
   bool warmup_;
   std::atomic<DiskANNCoreState> state_;
   RWLock rw_lock_;
+  static inline std::atomic<int64_t> aio_wait_count = 0;
 };
 
 }  // namespace dingodb

--- a/src/diskann/diskann_item.cc
+++ b/src/diskann/diskann_item.cc
@@ -1158,6 +1158,11 @@ butil::Status DiskANNItem::DoClose(std::shared_ptr<Context> ctx, bool is_destroy
   bool is_force = false;
   DiskANNCoreState state;
   if (diskann_core_) {
+    // if error occurred and errno == EDISKANN_AIO_NOT_ENOUGH,   is_force = true
+    // this is for avoiding diskann core reset fail
+    if (pb::error::Errno::EDISKANN_AIO_NOT_ENOUGH == last_error_.error_code()) {
+      is_force = true;
+    }
     auto status = diskann_core_->Reset(is_delete_files, state, is_force);
     if (!status.ok()) {
       std::string s = fmt::format("diskann DoClose fail : {}", status.error_cstr());

--- a/src/diskann/diskann_utils.h
+++ b/src/diskann/diskann_utils.h
@@ -76,6 +76,7 @@ class DiskANNUtils {
   static int64_t GetAioNr();
   static int64_t GetAioMaxNr();
   static void OutputAioRelatedInformation(uint32_t num_threads, uint32_t max_event);
+  static butil::Status CheckAioRelatedInformation(uint32_t num_threads, uint32_t max_event, int64_t aio_wait_count);
 
  protected:
  private:

--- a/test/unit_test/vector/test_diskann_item_concurrent.cc
+++ b/test/unit_test/vector/test_diskann_item_concurrent.cc
@@ -397,7 +397,7 @@ TEST_F(DiskANNItemConcurrentTest, Destroy) {
       ctx = std::make_shared<Context>();
       brpc::Controller cntl;
       ctx->SetCntl(&cntl);
-      status = disk_concurrent_item_l2->Destroy(ctx);
+      status = disk_concurrent_items[i]->Destroy(ctx);
       EXPECT_EQ(status.error_code(), pb::error::Errno::OK);
     }));
   }


### PR DESCRIPTION
[fix][index] Fix the crash problem caused by insufficient aio nr. At present, it is found that aio nr is insufficient. It only reports an error and no longer crashes.