### PR TITLE
[fix][index] Fix Diskann  Related issue.

### DIFF
--- a/src/diskann/diskann_core.cc
+++ b/src/diskann/diskann_core.cc
@@ -672,11 +672,12 @@ butil::Status DiskANNCore::DoLoad(const pb::common::LoadDiskAnnParam& load_param
       count = count_;
       metric_type = metric_type_;
       dim = dimension_;
+      metric = metric_;
     }
 
     // garbage diskann interface. I modify diskann interface.
     reader = std::make_shared<LinuxAlignedFileReader>();
-    flash_index = std::make_unique<diskann::PQFlashIndex<float>>(reader, metric_);
+    flash_index = std::make_unique<diskann::PQFlashIndex<float>>(reader, metric);
 
     try {
       index_path_prefix = index_path_prefix_;
@@ -813,8 +814,8 @@ butil::Status DiskANNCore::DoLoad(const pb::common::LoadDiskAnnParam& load_param
 }
 
 butil::Status DiskANNCore::DoPrepareTryLoad(const pb::common::CreateDiskAnnParam& diskann_parameter,
-                                            diskann::Metric& metric, pb::common::MetricType& metric_type, size_t& count,
-                                            size_t& dim, bool& build_with_mem_index) {
+                                            diskann::Metric& metric, const pb::common::MetricType& metric_type,
+                                            size_t& count, size_t& dim, bool& build_with_mem_index) {
   auto value_type = diskann_parameter.value_type();
   if (value_type == pb::common::ValueType::INT8_T) {
     std::string s = "diskann value_type not support int8";

--- a/src/diskann/diskann_core.h
+++ b/src/diskann/diskann_core.h
@@ -69,7 +69,7 @@ class DiskANNCore {
   butil::Status DoLoad(const pb::common::LoadDiskAnnParam& load_param, DiskANNCoreState old_state,
                        DiskANNCoreState& state, bool is_try_load);
   butil::Status DoPrepareTryLoad(const pb::common::CreateDiskAnnParam& diskann_parameter, diskann::Metric& metric,
-                                 pb::common::MetricType& metric_type, size_t& count, size_t& dim,
+                                 const pb::common::MetricType& metric_type, size_t& count, size_t& dim,
                                  bool& build_with_mem_index);
   butil::Status FillSearchResult(uint32_t topk, const std::vector<std::vector<float>>& distances,
                                  const std::vector<std::vector<uint64_t>>& labels,

--- a/src/diskann/diskann_item.cc
+++ b/src/diskann/diskann_item.cc
@@ -89,6 +89,8 @@ DiskANNItem::~DiskANNItem() {
 #endif
 }
 
+std::shared_ptr<DiskANNItem> DiskANNItem::GetSelf() { return shared_from_this(); }
+
 butil::Status DiskANNItem::Import(std::shared_ptr<Context> ctx, const std::vector<pb::common::Vector>& vectors,
                                   const std::vector<int64_t>& vector_ids, bool has_more,
                                   bool /*force_to_load_data_if_exist*/, int64_t already_send_vector_count, int64_t ts,
@@ -876,8 +878,9 @@ butil::Status DiskANNItem::DoSyncBuild(std::shared_ptr<Context> ctx, bool force_
 }
 
 butil::Status DiskANNItem::DoAsyncBuild(std::shared_ptr<Context> ctx, bool force_to_build, DiskANNCoreState old_state) {
-  auto lambda_call = [this, force_to_build, old_state, ctx]() {
-    this->DoBuildInternal(ctx, force_to_build, old_state);
+  std::shared_ptr<DiskANNItem> self = GetSelf();
+  auto lambda_call = [self, force_to_build, old_state, ctx]() {
+    self->DoBuildInternal(ctx, force_to_build, old_state);
   };
 
 #if defined(ENABLE_DISKANN_ITEM_PTHREAD)
@@ -966,7 +969,8 @@ butil::Status DiskANNItem::DoSyncLoad(std::shared_ptr<Context> ctx, const pb::co
 
 butil::Status DiskANNItem::DoAsyncLoad(std::shared_ptr<Context> ctx, const pb::common::LoadDiskAnnParam& load_param,
                                        DiskANNCoreState old_state) {
-  auto lambda_call = [this, &load_param, old_state, ctx]() { this->DoLoadInternal(ctx, load_param, old_state); };
+  std::shared_ptr<DiskANNItem> self = GetSelf();
+  auto lambda_call = [self, &load_param, old_state, ctx]() { self->DoLoadInternal(ctx, load_param, old_state); };
 
 #if defined(ENABLE_DISKANN_ITEM_PTHREAD)
   std::thread th(lambda_call);
@@ -1032,7 +1036,8 @@ butil::Status DiskANNItem::DoSyncTryLoad(std::shared_ptr<Context> ctx, const pb:
 
 butil::Status DiskANNItem::DoAsyncTryLoad(std::shared_ptr<Context> ctx, const pb::common::LoadDiskAnnParam& load_param,
                                           DiskANNCoreState old_state) {
-  auto lambda_call = [this, &load_param, old_state, ctx]() { this->DoTryLoadInternal(ctx, load_param, old_state); };
+  std::shared_ptr<DiskANNItem> self = GetSelf();
+  auto lambda_call = [self, &load_param, old_state, ctx]() { self->DoTryLoadInternal(ctx, load_param, old_state); };
 
 #if defined(ENABLE_DISKANN_ITEM_PTHREAD)
   std::thread th(lambda_call);

--- a/src/diskann/diskann_item.cc
+++ b/src/diskann/diskann_item.cc
@@ -1158,9 +1158,8 @@ butil::Status DiskANNItem::DoClose(std::shared_ptr<Context> ctx, bool is_destroy
   bool is_force = false;
   DiskANNCoreState state;
   if (diskann_core_) {
-    // if error occurred and errno == EDISKANN_AIO_NOT_ENOUGH,   is_force = true
-    // this is for avoiding diskann core reset fail
-    if (pb::error::Errno::EDISKANN_AIO_NOT_ENOUGH == last_error_.error_code()) {
+    // If an error has occurred, the object can be destroyed even during building or loading.
+    if (pb::error::Errno::OK != last_error_.error_code()) {
       is_force = true;
     }
     auto status = diskann_core_->Reset(is_delete_files, state, is_force);

--- a/src/diskann/diskann_item.h
+++ b/src/diskann/diskann_item.h
@@ -40,7 +40,7 @@ namespace dingodb {
 
 // #undef ENABLE_DISKANN_ID_MAPPING
 
-class DiskANNItem {
+class DiskANNItem : public std::enable_shared_from_this<DiskANNItem> {
  public:
   explicit DiskANNItem(std::shared_ptr<Context> ctx, int64_t vector_index_id,
                        const pb::common::VectorIndexParameter& vector_index_parameter, u_int32_t num_threads,
@@ -52,6 +52,8 @@ class DiskANNItem {
   DiskANNItem& operator=(const DiskANNItem& rhs) = delete;
   DiskANNItem(DiskANNItem&& rhs) = delete;
   DiskANNItem& operator=(DiskANNItem&& rhs) = delete;
+
+  std::shared_ptr<DiskANNItem> GetSelf();
 
   butil::Status Import(std::shared_ptr<Context> ctx, const std::vector<pb::common::Vector>& vectors,
                        const std::vector<int64_t>& vector_ids, bool has_more, bool force_to_load_data_if_exist,

--- a/src/vector/vector_index_diskann.h
+++ b/src/vector/vector_index_diskann.h
@@ -36,7 +36,7 @@ namespace dingodb {
 
 #undef TEST_VECTOR_INDEX_DISKANN_MOCK
 
-class VectorIndexDiskANN : public VectorIndex {
+class VectorIndexDiskANN : public VectorIndex, public std::enable_shared_from_this<VectorIndexDiskANN> {
  public:
   explicit VectorIndexDiskANN(int64_t id, const pb::common::VectorIndexParameter& vector_index_parameter,
                               const pb::common::RegionEpoch& epoch, const pb::common::Range& range,
@@ -50,6 +50,8 @@ class VectorIndexDiskANN : public VectorIndex {
   VectorIndexDiskANN& operator=(VectorIndexDiskANN&& rhs) = delete;
 
   static void Init();
+
+  std::shared_ptr<VectorIndexDiskANN> GetSelf();
 
   butil::Status Save(const std::string& path) override;
   butil::Status Load(const std::string& path) override;


### PR DESCRIPTION
    [fix][index] Fix DINGODB-2346 issue. Fixed the crash problem when
    calling try load atomic variables in index process.
    The reason is that asynchronous thread is used to access the destructor
    object members. Change to shared_ptr mode for passing.
    Other similar problems have also been fixed.

    [fix][index] Fixed the issue that the next time you start load, the wrong metric type
    is used.

    [fix][index] Fixed the problem that the reset operation cannot be called
    when build failed or load failed.