### PR TITLE
[fix][index] Fix the bug that diskann build pq data exceeds 2^31 squares. And optimize the error reporting time. It is only found on the index side.

### DIFF
--- a/src/common/constant.h
+++ b/src/common/constant.h
@@ -243,7 +243,7 @@ class Constant {
   // do not change this parameter or it will crash.
   inline static const int64_t kDiskannMinCount = 2;
   // max count of vectors for diskann
-  inline static const int64_t kDiskannMaxCount = std::numeric_limits<uint32_t>::max();
+  inline static const int64_t kDiskannMaxCount = std::numeric_limits<int32_t>::max();
   inline static const std::string kDiskannStore = "store";
   inline static const std::string kDiskannPathConfigName = "path";
   inline static const std::string kDiskannNumThreadsConfigName = "num_threads";

--- a/src/diskann/diskann_item.h
+++ b/src/diskann/diskann_item.h
@@ -71,6 +71,8 @@ class DiskANNItem : public std::enable_shared_from_this<DiskANNItem> {
   std::string Dump(std::shared_ptr<Context> ctx);
   butil::Status Count(std::shared_ptr<Context> ctx, int64_t& count);  // NOLINT
   butil::Status SetNoData(std::shared_ptr<Context> ctx);
+  butil::Status SetImportTooMany(std::shared_ptr<Context> ctx);
+
 
   static void SetImportTimeout(int64_t timeout_s) { DiskANNItem::import_timeout_s = timeout_s; }
   static void SetBaseDir(const std::string& base) { DiskANNItem::base_dir = base; }

--- a/src/diskann/diskann_service_handle.cc
+++ b/src/diskann/diskann_service_handle.cc
@@ -331,6 +331,30 @@ butil::Status DiskAnnServiceHandle::VectorSetNoData(std::shared_ptr<Context> ctx
   return status;
 }
 
+butil::Status DiskAnnServiceHandle::VectorSetImportTooMany(std::shared_ptr<Context> ctx, int64_t vector_index_id) {
+  butil::Status status;
+  auto item = item_manager.Find(vector_index_id);
+  if (item == nullptr) {
+    std::string s = fmt::format("vector_index_id : {} not  exists", vector_index_id);
+    DINGO_LOG(ERROR) << s;
+    status = butil::Status(pb::error::EINDEX_NOT_FOUND, s);
+    return status;
+  }
+
+  status = item->SetImportTooMany(ctx);
+  if (!status.ok()) {
+    DINGO_LOG(ERROR) << status.error_cstr();
+  }
+
+  pb::diskann::VectorSetImportTooManyResponse& response =
+      (dynamic_cast<pb::diskann::VectorSetImportTooManyResponse&>(*ctx->Response()));
+
+  ServiceHelper::SetError(response.mutable_last_error(), ctx->Status().error_code(), ctx->Status().error_str());
+  response.set_state(DiskANNUtils::DiskANNCoreStateToPb(ctx->DiskANNCoreStateX()));
+
+  return status;
+}
+
 butil::Status DiskAnnServiceHandle::VectorDump(std::shared_ptr<Context> ctx, int64_t vector_index_id) {
   butil::Status status;
   auto item = item_manager.Find(vector_index_id);

--- a/src/diskann/diskann_service_handle.h
+++ b/src/diskann/diskann_service_handle.h
@@ -59,6 +59,8 @@ class DiskAnnServiceHandle {
 
   static butil::Status VectorSetNoData(std::shared_ptr<Context> ctx, int64_t vector_index_id);
 
+  static butil::Status VectorSetImportTooMany(std::shared_ptr<Context> ctx, int64_t vector_index_id);
+
   static butil::Status VectorDump(std::shared_ptr<Context> ctx, int64_t vector_index_id);
 
   static butil::Status VectorDumpAll(std::shared_ptr<Context> ctx);

--- a/src/server/diskann_service.h
+++ b/src/server/diskann_service.h
@@ -74,6 +74,11 @@ class DiskAnnServiceImpl : public pb::diskann::DiskAnnService {
                        ::dingodb::pb::diskann::VectorSetNoDataResponse* response,
                        ::google::protobuf::Closure* done) override;
 
+  void VectorSetImportTooMany(google::protobuf::RpcController* controller,
+                              const ::dingodb::pb::diskann::VectorSetImportTooManyRequest* request,
+                              ::dingodb::pb::diskann::VectorSetImportTooManyResponse* response,
+                              ::google::protobuf::Closure* done) override;
+
   void VectorDump(google::protobuf::RpcController* controller, const ::dingodb::pb::diskann::VectorDumpRequest* request,
                   ::dingodb::pb::diskann::VectorDumpResponse* response, ::google::protobuf::Closure* done) override;
 

--- a/src/vector/vector_index_diskann.h
+++ b/src/vector/vector_index_diskann.h
@@ -133,6 +133,9 @@ class VectorIndexDiskANN : public VectorIndex, public std::enable_shared_from_th
   butil::Status SendVectorSetNoDataRequest(const google::protobuf::Message& request,
                                            google::protobuf::Message& response);
   butil::Status SendVectorSetNoDataRequestWrapper();
+  butil::Status SendVectorSetImportTooManyRequest(const google::protobuf::Message& request,
+                                           google::protobuf::Message& response);
+  butil::Status SendVectorSetImportTooManyRequestWrapper();
   butil::Status SendVectorBuildRequest(const google::protobuf::Message& request, google::protobuf::Message& response);
   butil::Status SendVectorBuildRequestWrapper(const pb::common::VectorBuildParameter& parameter,
                                               pb::common::DiskANNCoreState& state);


### PR DESCRIPTION
[fix][index] Fix the bug that diskann build pq data exceeds 2^31 squares. And optimize the error reporting time. It is only found on the index side.