### PR TITLE
[feat][index] Add DiskAnn vector type

### DIFF
--- a/src/server/index_service.cc
+++ b/src/server/index_service.cc
@@ -405,7 +405,8 @@ static butil::Status ValidateVectorAddRequest(StoragePtr storage, const pb::inde
         vector_index_wrapper->Type() == pb::common::VectorIndexType::VECTOR_INDEX_TYPE_FLAT ||
         vector_index_wrapper->Type() == pb::common::VectorIndexType::VECTOR_INDEX_TYPE_BRUTEFORCE ||
         vector_index_wrapper->Type() == pb::common::VectorIndexType::VECTOR_INDEX_TYPE_IVF_FLAT ||
-        vector_index_wrapper->Type() == pb::common::VectorIndexType::VECTOR_INDEX_TYPE_IVF_PQ) {
+        vector_index_wrapper->Type() == pb::common::VectorIndexType::VECTOR_INDEX_TYPE_IVF_PQ ||
+        vector_index_wrapper->Type() == pb::common::VectorIndexType::VECTOR_INDEX_TYPE_DISKANN) {
       if (vector.vector().float_values().size() != dimension) {
         return butil::Status(
             pb::error::EILLEGAL_PARAMTETERS,
@@ -2611,7 +2612,8 @@ static butil::Status ValidateIndexTxnPrewriteRequest(StoragePtr storage, const p
           vector_index_wrapper->Type() == pb::common::VectorIndexType::VECTOR_INDEX_TYPE_FLAT ||
           vector_index_wrapper->Type() == pb::common::VectorIndexType::VECTOR_INDEX_TYPE_BRUTEFORCE ||
           vector_index_wrapper->Type() == pb::common::VectorIndexType::VECTOR_INDEX_TYPE_IVF_FLAT ||
-          vector_index_wrapper->Type() == pb::common::VectorIndexType::VECTOR_INDEX_TYPE_IVF_PQ) {
+          vector_index_wrapper->Type() == pb::common::VectorIndexType::VECTOR_INDEX_TYPE_IVF_PQ ||
+          vector_index_wrapper->Type() == pb::common::VectorIndexType::VECTOR_INDEX_TYPE_DISKANN) {
         if (BAIDU_UNLIKELY(vector.vector().float_values().size() != dimension)) {
           return butil::Status(
               pb::error::EILLEGAL_PARAMTETERS,


### PR DESCRIPTION
[feat][index] Add DiskAnn vector type

mysql> CREATE TABLE test (        id bigint not null,        feature float array not null,        feature_id bigint not null,        diskann_id bigint not null,        description varchar not null,        category varchar not null,        rating bigint not null,        text_id bigint not null,        INDEX text_index TEXT(text_id, description, category, rating) engine=TXN_BTREE PARTITION BY RANGE values(10) parameters(text_fields='{"description": {"tokenizer": {"type": "stem"}}, "category": {"tokenizer": {"type": "stem"}}, "rating": {"tokenizer": {"type": "i64"}}, "text_id": {"tokenizer": {"type": "i64"}}}'),        index diskann_index vector(diskann_id, feature) PARTITION BY RANGE values(2) parameters(type=diskann, metricType=L2, dimension=8, max_degree=64, search_list_size=100),        primary key(id) ) engine=TXN_LSM;                                                                                        Query OK, 0 rows affected (1.90 sec)

mysql> insert into test values (1, array[0.19151945412158966, 0.6221087574958801, 0.43772774934768677, 0.7853586077690125, 0.7799758315086365, 0.27259260416030884, 0.2764642536640167, 0.801872193813324], 1, 1, 'Plastic Keyboard', 'Electronics', 4, 1),(2, array[0.959139347076416, 0.8759326338768005, 0.35781726241111755, 0.5009950995445251, 0.683462917804718, 0.7127020359039307, 0.37025076150894165, 0.5611962080001831], 2 , 2, 'Ergonomic metal keyboard', 'Electronics', 4, 2), (3, array[0.5050831437110901, 0.013768449425697327, 0.772826611995697, 0.8826411962509155, 0.36488598585128784, 0.6153962016105652, 0.07538124173879623, 0.3688240051269531], 3, 3, 'Sleek running shoes', 'Footwear', 5, 3), (4, array[0.9361401200294495, 0.6513781547546387, 0.39720258116722107, 0.7887301445007324, 0.3168361186981201, 0.5680986642837524, 0.8691273927688599, 0.4361734092235565], 4, 4, 'Plastic Keyboard', 'Electronics', 4, 4); 
Query OK, 4 rows affected (0.79 sec)

mysql> select * from disk_ann_build(test, diskann_index, 0);
+------------------------+----------------------+
| DISKANN_INDEX$REGIONID | DISKANN_INDEX$STATUS |
+------------------------+----------------------+
|                  80050 | BUILDING             |
|                  80051 | BUILDING             |
+------------------------+----------------------+
2 rows in set (0.13 sec)

mysql> select * from disk_ann_status(test, diskann_index);
+------------------------+----------------------+
| DISKANN_INDEX$REGIONID | DISKANN_INDEX$STATUS |
+------------------------+----------------------+
|                  80051 | UPDATEDPATH          |
|                  80050 | NODATA               |
+------------------------+----------------------+
2 rows in set (0.12 sec)

mysql> select * from disk_ann_load(test, diskann_index, 2, true);
ERROR 5001 (45000): io.dingodb.sdk.common.DingoClientException$RequestErrorException: DiskANN is no data
mysql> select * from disk_ann_load(test, diskann_index, 2, true, 80051);
+------------------------+----------------------+
| DISKANN_INDEX$REGIONID | DISKANN_INDEX$STATUS |
+------------------------+----------------------+
|                  80051 | LOADED               |
+------------------------+----------------------+
1 row in set (0.14 sec)

mysql> 
mysql> select * from disk_ann_status(test, diskann_index);
+------------------------+----------------------+
| DISKANN_INDEX$REGIONID | DISKANN_INDEX$STATUS |
+------------------------+----------------------+
|                  80050 | NODATA               |
|                  80051 | LOADED               |
+------------------------+----------------------+
2 rows in set (0.13 sec)

mysql> select * from vector(test, feature, array[0.8894774317741394, 0.7277960181236267, 0.692345142364502, 0.47235092520713806, 0.8568729162216187, 0.6647433042526245, 0.3333759307861328, 0.5181455016136169], 5);
+------+-----------------------------------------------------------------------------------------------+------------+------------+--------------------------+-------------+--------+---------+------------------------+
| ID   | FEATURE                                                                                       | FEATURE_ID | DISKANN_ID | DESCRIPTION              | CATEGORY    | RATING | TEXT_ID | DISKANN_INDEX$DISTANCE |
+------+-----------------------------------------------------------------------------------------------+------------+------------+--------------------------+-------------+--------+---------+------------------------+
|    1 | [0.19151945, 0.62210876, 0.43772775, 0.7853586, 0.77997583, 0.2725926, 0.27646425, 0.8018722] |          1 |          1 | Plastic Keyboard         | Electronics |      4 |       1 |             0.90455407 |
|    2 | [0.95913935, 0.87593263, 0.35781726, 0.5009951, 0.6834629, 0.71270204, 0.37025076, 0.5611962] |          2 |          2 | Ergonomic metal keyboard | Electronics |      4 |       2 |             0.17511082 |
|    4 | [0.9361401, 0.65137815, 0.39720258, 0.78873014, 0.31683612, 0.56809866, 0.8691274, 0.4361734] |          4 |          4 | Plastic Keyboard         | Electronics |      4 |       4 |               0.789951 |
|    3 | [0.50508314, 0.013768449, 0.7728266, 0.8826412, 0.364886, 0.6153962, 0.07538124, 0.368824]    |          3 |          3 | Sleek running shoes      | Footwear    |      5 |       3 |              1.1657542 |
+------+-----------------------------------------------------------------------------------------------+------------+------------+--------------------------+-------------+--------+---------+------------------------+
4 rows in set (0.45 sec)

mysql>