### PR TITLE
[feat][store] The default block_cache_size of rocksdb is 1GB. Increase it to 2GB to improve concurrent query performance. Add it to the configuration file.

### DIFF
--- a/conf/coordinator.template.yaml
+++ b/conf/coordinator.template.yaml
@@ -39,6 +39,7 @@ log:
   path: $BASE_PATH$/log
 store:
   path: $BASE_PATH$/data/db
+  block_cache_size: 2147483648 # 2GB
   background_thread_num: 16 # background_thread_num priority background_thread_ratio
   # background_thread_ratio: 0.5 # cpu core * ratio
   stats_dump_period_s: 120

--- a/conf/document.template.yaml
+++ b/conf/document.template.yaml
@@ -40,6 +40,7 @@ document:
   enable_follower_hold_index: false
 store:
   path: $BASE_PATH$/data/db
+  block_cache_size: 2147483648 # 2GB
   background_thread_num: 16 # background_thread_num priority background_thread_ratio
   fast_background_thread_num: 8 # background_thread_num priority background_thread_ratio
   # background_thread_ratio: 0.5 # cpu core * ratio

--- a/conf/index.template.yaml
+++ b/conf/index.template.yaml
@@ -41,6 +41,7 @@ vector:
   enable_follower_hold_index: false
 store:
   path: $BASE_PATH$/data/db
+  block_cache_size: 2147483648 # 2GB
   background_thread_num: 16 # background_thread_num priority background_thread_ratio
   fast_background_thread_num: 8 # background_thread_num priority background_thread_ratio
   # background_thread_ratio: 0.5 # cpu core * ratio

--- a/conf/store.template.yaml
+++ b/conf/store.template.yaml
@@ -20,7 +20,7 @@ region:
   merge_check_interval_s: 120
   max_merge_region_size: 1048576 # 1MB
   max_merge_region_keys: 10000
-  split_merge_interval: 3600  #1h
+  split_merge_interval: 3600 #1h
   merge_size_ratio: 0.2
   merge_keys_ratio: 0.2
   merge_check_concurrency: 3
@@ -38,6 +38,7 @@ log:
   path: $BASE_PATH$/log
 store:
   path: $BASE_PATH$/data/db
+  block_cache_size: 2147483648 # 2GB
   background_thread_num: 16 # background_thread_num priority background_thread_ratio
   # background_thread_ratio: 0.5 # cpu core * ratio
   stats_dump_period_s: 120

--- a/src/common/constant.h
+++ b/src/common/constant.h
@@ -109,7 +109,7 @@ class Constant {
   inline static const std::string kBlockSize = "block_size";
   inline static const std::string kBlockSizeDefaultValue = "131072";  // 128KB
   inline static const std::string kBlockCache = "block_cache";
-  inline static const std::string kBlockCacheDefaultValue = "1073741824";  // 1GB
+  inline static const std::string kBlockCacheDefaultValue = "2147483648";  // 2GB
   inline static const std::string kArenaBlockSize = "arena_block_size";
   inline static const std::string kArenaBlockSizeDefaultValue = "67108864";  // 64MB
   inline static const std::string kMinWriteBufferNumberToMerge = "min_write_buffer_number_to_merge";


### PR DESCRIPTION
[feat][store] The default block_cache_size of rocksdb is 1GB. Increase it to 2GB to improve concurrent query performance. Add it to the configuration file.