### PR TITLE
[ci] Strip release binaries; publish :<tag>-debug sidecar image; switch runtime to multi-stage minimal base

### DIFF
--- a/.github/workflows/release-dockerhub.yml
+++ b/.github/workflows/release-dockerhub.yml
@@ -1,132 +1,166 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Release-Dockerhub
 
-# Controls when the workflow will run
+# Triggered by the CMake_rocky8 build completing on a non-PR push.
+#
+# Internally split into two jobs to keep concerns separated while
+# avoiding the fragility of chaining via `workflow_run`:
+#
+#   prepare_release_artifacts  → strip + repack + expose metadata
+#   build_and_push_images      → docker build + push (main + sidecar)
+#
+# The jobs flow via `needs`, so all artifacts and metadata stay
+# within a single workflow run — no cross-run race conditions.
+
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
   workflow_run:
     workflows: ["CMake_rocky8"]
     types:
       - completed
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  release:
-    # The type of runner that the job will run on
-    if: github.event.pull_request.merged == false
+  prepare_release_artifacts:
+    # Only run for successful, non-PR upstream builds. PRs are filtered
+    # here so subsequent docker-meta / push steps never even start for PRs.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      branch_name: ${{ steps.metadata.outputs.branch_name }}
+      commit_id:   ${{ steps.metadata.outputs.commit_id }}
+      event:       ${{ steps.metadata.outputs.event }}
+      tag_name:    ${{ steps.metadata.outputs.tag_name }}
+    steps:
+      - name: Download all artifacts from CMake_rocky8
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ./incoming/
+
+      - name: List downloaded artifacts
+        run: ls -laR ./incoming/
+
+      - name: Strip release binaries and separate debug info
+        run: |
+          set -euo pipefail
+
+          # objcopy and readelf come from binutils, pre-installed on the runner.
+          mkdir -p stage
+          tar -zxvf ./incoming/dingo-store.tar.gz/dingo-store.tar.gz -C stage
+          cd stage
+
+          for bin in build/bin/dingodb_server build/bin/dingodb_cli \
+                     build/bin/dingodb_br     build/bin/dingodb_client; do
+            # Build-id is required for .gnu_debuglink and any future
+            # debuginfod workflow. Debian dh_strip and RHEL find-debuginfo
+            # behave the same way and bail without a build-id.
+            if ! readelf -n "$bin" | grep -q 'Build ID'; then
+              echo "FATAL: $bin has no build-id; add -Wl,--build-id=sha1 to LINKFLAGS"
+              exit 1
+            fi
+            objcopy --only-keep-debug "$bin" "$bin.debug"
+            objcopy --strip-debug     "$bin"
+            objcopy --add-gnu-debuglink="$bin.debug" "$bin"
+            chmod -x "$bin.debug"
+            echo "stripped $(basename $bin): $(ls -lh $bin | awk '{print $5}') (debug: $(ls -lh $bin.debug | awk '{print $5}'))"
+          done
+
+          cd ..
+          tar -czvf dingo-store.tar.gz \
+            -C stage scripts build/bin/dingodb_server build/bin/dingodb_cli \
+                     build/bin/dingodb_br     build/bin/dingodb_client conf
+          tar -czvf dingo-store-debug.tar.gz \
+            -C stage build/bin/dingodb_server.debug build/bin/dingodb_cli.debug \
+                     build/bin/dingodb_br.debug     build/bin/dingodb_client.debug
+
+      - name: Upload stripped runtime artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dingo-store.tar.gz
+          path: ./dingo-store.tar.gz
+
+      - name: Upload debug artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dingo-store-debug.tar.gz
+          path: ./dingo-store-debug.tar.gz
+
+      - name: Extract metadata to job outputs
+        id: metadata
+        run: |
+          set -eu
+
+          # Required: ci_rocky8.yml always produces these on any push/PR.
+          # Failing fast here surfaces a broken upstream artifact contract
+          # immediately, instead of letting Job 2 fail in docker/metadata-action
+          # with an inscrutable error.
+          for required in branch_name commit_id event; do
+            file="./incoming/${required}/${required}.txt"
+            if [ ! -f "$file" ]; then
+              echo "FATAL: required upstream metadata file missing: $file" >&2
+              echo "This means ci_rocky8.yml's metadata artifact contract is broken." >&2
+              exit 1
+            fi
+            echo "${required}=$(cat "$file")" >> "$GITHUB_OUTPUT"
+          done
+
+          # Optional: only present on tag pushes. Tag publishing is not
+          # currently wired in ci_rocky8.yml (no on.push.tags:), so this
+          # file is expected to be absent in practice today.
+          if [ -f ./incoming/tag_name/tag_name.txt ]; then
+            echo "tag_name=$(cat ./incoming/tag_name/tag_name.txt)" >> "$GITHUB_OUTPUT"
+          fi
+
+  build_and_push_images:
+    needs: prepare_release_artifacts
+    # Belt-and-suspenders job-level guard:
+    #   1. result == 'success' — explicit (GHA defaults this on needs, but
+    #      we make it visible).
+    #   2. event != '' — never run when upstream metadata is empty (Job 1's
+    #      fail-fast should already prevent this, but be explicit).
+    #   3. event != 'pull_request' — defense against PR builds slipping
+    #      through if event.txt is malformed.
+    if: |
+      needs.prepare_release_artifacts.result == 'success' &&
+      needs.prepare_release_artifacts.outputs.event != '' &&
+      needs.prepare_release_artifacts.outputs.event != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
+    env:
+      BRANCH_NAME: ${{ needs.prepare_release_artifacts.outputs.branch_name }}
+      COMMIT_ID:   ${{ needs.prepare_release_artifacts.outputs.commit_id }}
+      EVENT:       ${{ needs.prepare_release_artifacts.outputs.event }}
+      TAG_NAME:    ${{ needs.prepare_release_artifacts.outputs.tag_name }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download branch name file
+      - name: Download stripped runtime artifact
         uses: actions/download-artifact@v4
         with:
-          name: branch_name
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: ./
+          name: dingo-store.tar.gz
+          path: ./docker/
 
-      - name: Config trigger branch env
-        run: |
-          if [ -f branch_name.txt ]; then
-            echo "BRANCH_NAME=$(cat branch_name.txt)" >> $GITHUB_ENV
-          fi
-
-      - name: Download commit id file
+      - name: Download debug artifact
         uses: actions/download-artifact@v4
         with:
-          name: commit_id
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: ./
+          name: dingo-store-debug.tar.gz
+          path: ./docker/
 
-      - name: Config commit id env
-        run: |
-          if [ -f commit_id.txt ]; then
-            echo "COMMIT_ID=$(cat commit_id.txt)" >> $GITHUB_ENV
-          fi
-
-      - name: Download event type file
-        uses: actions/download-artifact@v4
-        with:
-          name: event
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: ./
-
-      - name: Config trigger event env
-        run: |
-          if [ -f event.txt ]; then
-            echo "EVENT=$(cat event.txt)" >> $GITHUB_ENV
-          fi
-
-      - name: Download tag name file
-        if: ${{ env.EVENT == 'tag' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: tag_name
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: ./
-
-      - name: Config push tag env
-        if: ${{ env.EVENT == 'tag' }}
-        run: |
-          if [ -f tag_name.txt ]; then
-            echo "TAG_NAME=$(cat tag_name.txt)" >> $GITHUB_ENV
-          fi
-
-      - name: Print env info
-        id: check-event
-        run: |
-          echo "trigger event type is ${{ env.EVENT }}"
-          echo "continue=true" >> $GITHUB_OUTPUT
-          if [ "${{ env.EVENT }}" == "pull_request" ]; then
-            echo "pull request haven't merged, not need to publish image."
-            echo "continue=false" >> $GITHUB_OUTPUT
-          fi
-          if [ -n "${{ env.TAG_NAME }}" ]; then
-            echo "tag name is ${{ env.TAG_NAME }}, need to publish image."
-          fi
-          if [ -n "${{ env.BRANCH_NAME }}" ]; then
-            echo "branch name is ${{ env.BRANCH_NAME }}"
-          fi
-          if [ -n "${{ env.COMMIT_ID }}" ]; then
-            echo "commit id is ${{ env.COMMIT_ID }}"
-          fi
-
-      - name: Download artifact
-        if: steps.check-event.outputs.continue == 'true'
-        uses: dawidd6/action-download-artifact@v2
-        with:
-            github_token: ${{secrets.GITHUB_TOKEN}}
-            workflow: ci_rocky8.yml
-            name: dingo-store.tar.gz
-
-      - name: rename artifactory name
-        if: steps.check-event.outputs.continue == 'true'
-        run: |
-            cp dingo-store.tar.gz ./docker
-
-      # setup Docker buld action
       - name: Set up Docker Buildx
-        if: steps.check-event.outputs.continue == 'true'
-        id: buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Github Packages
-        if: steps.check-event.outputs.continue == 'true'
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta info
-        if: steps.check-event.outputs.continue == 'true'
         id: store-meta
         uses: docker/metadata-action@v5
         with:
@@ -138,17 +172,32 @@ jobs:
             type=raw,value=${{ env.BRANCH_NAME }}-${{ env.COMMIT_ID }},enable=${{ env.EVENT != 'tag' && env.BRANCH_NAME != 'main' }}
             type=raw,value=${{ env.BRANCH_NAME }}-latest,enable=${{ env.EVENT != 'tag' && env.BRANCH_NAME != 'main' }}
 
-      - name: Build image and push to Docker Hub and GitHub Container Registry
-        if: steps.check-event.outputs.continue == 'true'
+      - name: Docker meta info (debug sidecar)
+        id: store-debug-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: dingodatabase/dingo-store
+          flavor: |
+            suffix=-debug,onlatest=true
+          tags: |
+            type=raw,enable=${{ env.EVENT == 'tag' }},value=${{ env.TAG_NAME }}
+            type=raw,value=latest,enable=${{ env.BRANCH_NAME == 'main' && env.EVENT != 'tag'}}
+            type=sha,prefix=,format=short,enable=${{ env.BRANCH_NAME == 'main' && env.EVENT != 'tag' }}
+            type=raw,value=${{ env.BRANCH_NAME }}-${{ env.COMMIT_ID }},enable=${{ env.EVENT != 'tag' && env.BRANCH_NAME != 'main' }}
+            type=raw,value=${{ env.BRANCH_NAME }}-latest,enable=${{ env.EVENT != 'tag' && env.BRANCH_NAME != 'main' }}
+
+      - name: Build runtime image and push to Docker Hub
         uses: docker/build-push-action@v6
         with:
-          # relative path to the place where source code with Dockerfile is located
           context: ./docker
-          #tags: dingodatabase/dingo-store:latest
+          file: ./docker/Dockerfile
           tags: ${{ steps.store-meta.outputs.tags }}
-          # push: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' }}
           push: true
 
-      - name: Image digest
-        if: steps.check-event.outputs.continue == 'true'
-        run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Build debug sidecar image and push to Docker Hub
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker
+          file: ./docker/Dockerfile.debug
+          tags: ${{ steps.store-debug-meta.outputs.tags }}
+          push: true

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ make
 cd java && mvn clean package -DskipTests
 ```
 
+### Debug Symbols
+
+Release images ship stripped binaries with the matching DWARF symbols
+distributed as a sidecar image `dingodatabase/dingo-store:<tag>-debug`.
+See [docs/debug-symbols.md](./docs/debug-symbols.md) for the SRE
+crash-analysis workflow, local debugging tips, and common pitfalls.
+
 ## How to make a clean pull request
 
 - Create a personal fork of dingo on GitHub.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,54 @@
-FROM dingodatabase/dingo-base:rocky8
+# Multi-stage build + minimal runtime base.
+#
+# Builder stage uses dingo-base:rocky8 (same image that ci_rocky8.yml's
+# build env extends), guaranteeing glibc / libstdc++ ABI compatibility
+# with the stripped binary produced by prepare_release_artifacts.
+#
+# Runtime stage uses rockylinux:8-minimal (~140 MB) and installs only
+# the shared libraries that `ldd dingodb_server` actually requires:
+#
+#   linux-vdso, ld-linux, libdl, librt, libpthread, libm, libc → glibc
+#   libstdc++.so.6                                             → libstdc++
+#   libgcc_s.so.1                                              → libgcc (auto)
+#
+# All heavy dependencies (brpc, braft, rocksdb, boost, openssl, MKL,
+# ...) are statically linked into the binary upstream, so the runtime
+# image stays slim. See docs/debug-symbols.md for the full pipeline.
+
+ARG BUILDER_IMAGE=dingodatabase/dingo-base:rocky8
+FROM ${BUILDER_IMAGE} AS builder
+
+COPY ./dingo-store.tar.gz /opt/
+RUN cd /opt \
+    && mkdir dingo-store \
+    && tar -zxvf dingo-store.tar.gz -C dingo-store \
+    && chmod +x -R /opt/dingo-store/* \
+    && sed -i 's/electionTimeout: [0-9]\+/electionTimeout: 30000/g' /opt/dingo-store/conf/store.template.yaml \
+    && sed -i 's/electionTimeout: [0-9]\+/electionTimeout: 30000/g' /opt/dingo-store/conf/coordinator.template.yaml \
+    && rm /opt/dingo-store.tar.gz
+
+FROM rockylinux:8-minimal
 
 ENV TZ=Asia/Shanghai
 SHELL ["/bin/bash", "-c"]
 
-RUN dnf update -y  \
-    && dnf install -y vim unzip net-tools tzdata wget git gcc gcc-c++ make automake openssl openssl-devel gcc-toolset-13* libtool patch libaio-devel boost-devel \
-    && dnf clean all \
+# Runtime-only packages: only what `ldd dingodb_server` requires plus
+# minimal shell tools for docker-dingo-store.sh / deploy_func.sh
+# (sed/awk/grep are already in rockylinux:8-minimal base).
+RUN microdnf install -y \
+        libstdc++ \
+        procps-ng \
+        findutils \
+        tzdata \
+        net-tools \
+        iproute \
+    && microdnf clean all \
     && ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime \
-    && echo ${TZ} > /etc/timezone \
-    && unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+    && echo ${TZ} > /etc/timezone
 
-COPY ./dingo-store.tar.gz  /opt
+COPY --from=builder /opt/dingo-store /opt/dingo-store
 
-RUN cd /opt && mkdir dingo-store && tar -zxvf dingo-store.tar.gz -C dingo-store && chmod +x -R /opt/dingo-store/* && sed -i 's/electionTimeout: [0-9]\+/electionTimeout: 30000/g' /opt/dingo-store/conf/store.template.yaml && sed -i 's/electionTimeout: [0-9]\+/electionTimeout: 30000/g' /opt/dingo-store/conf/coordinator.template.yaml
-
-ENV PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
 WORKDIR /opt/dingo-store
 
-ENTRYPOINT [ "/opt/dingo-store/scripts/docker-dingo-store.sh" ]
+ENTRYPOINT ["/opt/dingo-store/scripts/docker-dingo-store.sh"]
 CMD ["cleanstart"]

--- a/docker/Dockerfile.debug
+++ b/docker/Dockerfile.debug
@@ -1,0 +1,41 @@
+# Dockerfile.debug — sidecar image containing detached DWARF debug info
+#
+# This image extends dingodatabase/dingo-store:<tag> with .debug files placed
+# next to each stripped binary at /opt/dingo-store/build/bin/. gdb auto-loads
+# them via the .gnu_debuglink section embedded in each binary by
+# `objcopy --add-gnu-debuglink` during the CI build step.
+#
+# This is the standard equivalent of Debian -dbgsym / RHEL -debuginfo packages,
+# packaged as a Docker image for production crash analysis workflows.
+#
+# Recommended usage (SRE crash-analysis workflow, host needs no debug tools):
+#
+#   docker pull dingodatabase/dingo-store:<tag>-debug
+#   docker run --rm -it \
+#     -v /path/to/core.<pid>:/core:ro \
+#     --entrypoint=gdb \
+#     dingodatabase/dingo-store:<tag>-debug \
+#       /opt/dingo-store/build/bin/dingodb_server /core
+#   # gdb finds the .debug file via .gnu_debuglink. See
+#   # docs/debug-symbols.md for the K8s ephemeral-debug-container
+#   # variant and host-side fallback.
+
+ARG STORE_TAG=latest
+FROM dingodatabase/dingo-store:${STORE_TAG}
+
+SHELL ["/bin/bash", "-c"]
+
+# Sidecar adds the .debug files AND the debugger so SREs can drop into
+# `docker run :-debug gdb` directly without host-side tooling. The main
+# runtime image is built on rockylinux:8-minimal which doesn't have tar
+# or gdb by default, so install them here.
+RUN microdnf install -y gdb tar gzip \
+    && microdnf clean all
+
+COPY dingo-store-debug.tar.gz /tmp/
+RUN set -eu \
+    && cd /tmp \
+    && tar -zxvf dingo-store-debug.tar.gz \
+    && mv build/bin/dingodb_*.debug /opt/dingo-store/build/bin/ \
+    && rm -rf /tmp/build /tmp/dingo-store-debug.tar.gz \
+    && ls -lh /opt/dingo-store/build/bin/*.debug

--- a/docs/debug-symbols.md
+++ b/docs/debug-symbols.md
@@ -1,0 +1,308 @@
+# 调试符号（Debug Symbols）
+
+本文档说明 Dingo-Store 在 release 流程中如何打包、分发调试符号，
+以及生产 crash 排查时如何使用。
+
+## 为什么要分离调试符号？
+
+CI 用 `RelWithDebInfo` 模式编译 `dingo-store` 各个 binary。这种模式
+产出的是开启优化、同时携带完整 DWARF 调试信息的二进制，所以**单个
+`dingodb_server` 大约 1.1 GB**——其中约 91% 是 DWARF 段（loader
+运行时并不会加载这些段，只是占文件体积）。
+
+为了让生产镜像瘦下来又不丢调试能力，release 流程把每个 binary 拆成
+两份产物：
+
+- **Stripped binary**（`/opt/dingo-store/build/bin/dingodb_server`）
+  随 `dingodatabase/dingo-store:<tag>` 镜像发布。仅保留 runtime 需要
+  的 ELF 段，体积约 **88 MB**。
+- **Debug companion**（`dingodb_server.debug`）随
+  `dingodatabase/dingo-store:<tag>-debug` sidecar 镜像发布。纯 DWARF
+  调试信息，体积约 **1 GB**。
+
+这套做法等价于 **Debian `-dbgsym`** 子包 / **RHEL `-debuginfo`** 子包
+的工业惯例，只是把发布载体换成了 Docker 镜像。
+
+## 工作原理（`.gnu_debuglink` + build-id）
+
+拆分动作在 `.github/workflows/release-dockerhub.yml` 的
+`prepare_release_artifacts` job 里跑，对每个 `dingodb_*` binary 做
+标准 binutils 三步：
+
+```bash
+objcopy --only-keep-debug  dingodb_server  dingodb_server.debug
+objcopy --strip-debug      dingodb_server
+objcopy --add-gnu-debuglink=dingodb_server.debug  dingodb_server
+```
+
+三步执行完，stripped 后的 `dingodb_server` 在 ELF 内部会多出一个
+`.gnu_debuglink` 段——里面记着 `.debug` 文件名 + CRC32 校验值。
+同时 binary 跟 `.debug` 都保留链接器生成的 `.note.gnu.build-id`
+（一个 SHA-1 fingerprint），这是两者一一对应的锚点。
+
+gdb、addr2line、perf、elfutils 等所有标准工具都原生支持这套机制：
+拿到 stripped binary 后，工具会按以下路径自动寻找配对的 `.debug`
+文件，加载后跟未 strip 的体验完全一致：
+
+- binary 同目录下的 `<basename>.debug`
+- 同目录下 `.debug/` 子目录
+- `/usr/lib/debug/.build-id/NN/<rest>.debug`（按 build-id 哈希路径）
+
+## 镜像如何发布到 Docker Hub
+
+镜像发布由两个 workflow 驱动：`ci_rocky8.yml`（负责编译）和
+`release-dockerhub.yml`（负责打包 + push）。后者内部拆成两个 job
+保持职责分层。
+
+### 整体架构
+
+镜像构建采用**两阶段多 stage 设计**：build 阶段使用 dingo-base:rocky8
+（确保 glibc / libstdc++ ABI 兼容上游 `ci_rocky8.yml` 的 build env），
+runtime 阶段切到 `rockylinux:8-minimal`（~140 MB）+ 仅装 binary 实际
+依赖的 `.so`（`ldd dingodb_server` 验证）。Sidecar 镜像 FROM 主 runtime
+再装 `gdb` + `tar` 等调试工具。
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ ci_rocky8.yml（不变）                                        │
+│  on: push/PR to main/develop/quickBI-v3.0.0                 │
+│  └─ 上传 4 个常规 artifact:                                  │
+│       dingo-store.tar.gz, branch_name, commit_id, event     │
+│     + 1 个条件 artifact: tag_name（仅 tag push 时；见 NOTE）│
+└─────────────────────────┬───────────────────────────────────┘
+                          │ workflow_run on CMake_rocky8
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│ release-dockerhub.yml(2 个 job)                              │
+│                                                             │
+│  ┌────────────────────────────────────────────────────────┐ │
+│  │ Job 1: prepare_release_artifacts                       │ │
+│  │   if: workflow_run.conclusion == 'success' &&          │ │
+│  │       workflow_run.event != 'pull_request'             │ │
+│  │   permissions: { actions: read }                       │ │
+│  │   ├─ 从 CMake_rocky8 下载 ci_rocky8 上传的全部 artifact│ │
+│  │   │   (actions/download-artifact@v4 + run-id +         │ │
+│  │   │    github-token)                                   │ │
+│  │   ├─ 对 4 个 binary 跑 objcopy 三步 strip              │ │
+│  │   ├─ 重新打包:                                          │ │
+│  │   │   - dingo-store.tar.gz       (stripped 运行包)     │ │
+│  │   │   - dingo-store-debug.tar.gz (4 个 .debug 文件)    │ │
+│  │   ├─ 把这两个 artifact 上传到当前 workflow run         │ │
+│  │   └─ outputs (3 个必需项 fail-fast + 1 个可选项):       │ │
+│  │       branch_name, commit_id, event, tag_name          │ │
+│  └──────────────────────────┬─────────────────────────────┘ │
+│                             │ needs: prepare_release_artifacts
+│                             ▼                               │
+│  ┌────────────────────────────────────────────────────────┐ │
+│  │ Job 2: build_and_push_images                           │ │
+│  │   needs: [prepare_release_artifacts]                   │ │
+│  │   if: result == 'success'                              │ │
+│  │       && event != '' && event != 'pull_request'        │ │
+│  │   permissions: { packages: write, contents: read }     │ │
+│  │   env:                                                 │ │
+│  │     BRANCH_NAME: ${{ needs.X.outputs.branch_name }}    │ │
+│  │     COMMIT_ID:   ${{ needs.X.outputs.commit_id }}      │ │
+│  │     EVENT:       ${{ needs.X.outputs.event }}          │ │
+│  │     TAG_NAME:    ${{ needs.X.outputs.tag_name }}       │ │
+│  │   ├─ 从同 workflow run 下载 stripped + debug 两个 tar  │ │
+│  │   │   (actions/download-artifact@v4, 默认 same-run)    │ │
+│  │   ├─ Docker meta × 2 (runtime + debug sidecar)         │ │
+│  │   └─ Build + push 两个镜像                              │ │
+│  └────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Job 职责边界
+
+| Job | 输入 | 输出 | 责任 |
+|---|---|---|---|
+| **prepare_release_artifacts** | CMake_rocky8 的 artifact（4 常规 + 0/1 条件 tag_name） | 2 个新 artifact（stripped tar + debug tar）+ 4 个 job outputs（metadata，3 必需 + 1 可选） | **打包**：把 build 产物变成 release-ready 产物 |
+| **build_and_push_images** | Job 1 的 artifacts + outputs | 2 个 Docker Hub tag（`:<tag>` + `:<tag>-debug`）| **发布**：拿发布包做镜像并 push |
+
+其他 CI workflow（`ci_rocky9.yml`、`ci_ubuntu.yml`）只负责多发行版
+build 验证，**不发布任何镜像**。
+
+`ci_rocky8.yml` 保持极简——只跑 `RelWithDebInfo` 编译 + 上传原始
+artifact。所有 release-only 的处理（strip、调试信息分离、重新打包、
+镜像 build、push）都集中在 `release-dockerhub.yml` 里。两个 job 在
+**同一次 workflow run 内**通过 `needs` 串起来，所有 artifact 留在
+同 run namespace，不依赖 `workflow_run` 跨 run 查找，从根上避免了
+"按名字找 artifact" 的竞态。
+
+### 触发条件
+
+| Git 事件 | push 到 Docker Hub 的 tag |
+|---|---|
+| Push 到 `main` | `:latest` + `:<sha7>`（如 `:729a688`）|
+| Push 到 `develop` / `quickBI-v3.0.0` | `:<branch>-<sha7>` + `:<branch>-latest` |
+| Git tag push（`refs/tags/<name>`）| `:<name>`（如 `:v1.0.0`）—— 见下方 NOTE |
+| Pull request | 无——CI 会跑 build，但 `release-dockerhub.yml` 的 publish job 被 `if` 短路 |
+
+> **关于 tag publishing 的 NOTE**：tag publishing 的 tag 规则在
+> `release-dockerhub.yml` 里已经编码完整，但上游 `ci_rocky8.yml` 只
+> 配了 `on.push.branches:` 没配 `on.push.tags:`，所以 tag push 当前
+> **不会触发**本管线。这条路径保留下来，方便未来给 `ci_rocky8.yml`
+> 补上 `tags:` 过滤后立即生效。
+
+每个主镜像 tag 都配套发布一个 `-debug` sidecar：
+
+| 主镜像 tag | 配套 sidecar tag |
+|---|---|
+| `:latest` | `:latest-debug` |
+| `:<sha7>` | `:<sha7>-debug` |
+| `:<branch>-<sha7>` | `:<branch>-<sha7>-debug` |
+| `:<branch>-latest` | `:<branch>-latest-debug` |
+| `:v1.0.0` | `:v1.0.0-debug` |
+
+sidecar 镜像基于 `docker/Dockerfile.debug` 构建，本质是
+`FROM dingodatabase/dingo-store:${STORE_TAG}` 再叠一层 `.debug`
+文件到 `/opt/dingo-store/build/bin/`。因为 `FROM` 复用主镜像所有
+layer，已经拉过主镜像的用户拉 sidecar 几乎是增量下载。
+
+### Build pipeline 详细流程
+
+```
+ci_rocky8.yml（RelWithDebInfo build）
+    ├─ cmake --build → 4 个带完整 DWARF 的 binary
+    └─ tar -czvf dingo-store.tar.gz（4 binary + scripts + conf）
+        │
+        ▼（上传为 artifact + 3 个必需 metadata .txt + 1 个条件 tag_name.txt）
+        │
+release-dockerhub.yml（workflow_run 监听 CMake_rocky8）
+  │
+  ├─ job: prepare_release_artifacts
+  │     ├─ 从 CMake_rocky8 下载全部 artifacts
+  │     │   （actions/download-artifact@v4 + run-id + github-token，
+  │     │    需要 actions:read 权限）
+  │     ├─ 对 4 个 dingodb_* binary 跑 objcopy 三步
+  │     ├─ 重打 dingo-store.tar.gz（stripped + scripts + conf）
+  │     ├─ 打包 dingo-store-debug.tar.gz（4 个 .debug 文件）
+  │     ├─ 把这两个 tarball 作为本次 workflow run 的 artifact 上传
+  │     └─ 把 metadata（branch_name / commit_id / event / tag_name）
+  │        暴露为 job outputs（无需文件转发）
+  │
+  └─ job: build_and_push_images（needs: prepare_release_artifacts）
+        ├─ 下载 dingo-store.tar.gz       → ./docker/（同 run namespace，无需 run-id）
+        ├─ 下载 dingo-store-debug.tar.gz → ./docker/（同上）
+        ├─ 从 needs.prepare_release_artifacts.outputs 解析镜像 tag
+        ├─ docker build -f docker/Dockerfile       → dingodatabase/dingo-store:<tag>
+        └─ docker build -f docker/Dockerfile.debug → dingodatabase/dingo-store:<tag>-debug
+```
+
+主镜像 tag 跟 `-debug` sidecar tag 一定指向同一个 git commit——因为
+两者都由同一次 `release-dockerhub.yml` run 产出，跑的是同一组 strip
+后的 binary（同 `.note.gnu.build-id`），不可能版本错配。
+
+## SRE 工作流
+
+生产环境某个 server 跑挂了拿到 core file 之后，**推荐直接用 sidecar
+镜像内的 gdb 跑，host 零依赖**——`:<tag>-debug` 镜像里已预装
+`gdb` + `tar` + 必要工具，跟主镜像同 rocky8-minimal base 同 glibc /
+libstdc++，省去 host 上对 gdb 版本 / glibc-debuginfo / sysroot 等的
+各种适配。
+
+```bash
+# 1. 看生产 pod 跑的镜像 tag
+kubectl describe pod <victim-pod> | grep Image:
+# Image: dingodatabase/dingo-store:abc1234
+
+# 2. 拉配套的 :-debug sidecar 镜像（同 tag + -debug 后缀，主镜像 layer 已缓存则增量小）
+docker pull dingodatabase/dingo-store:abc1234-debug
+
+# 3. 把 core 文件 mount 进 sidecar 镜像、直接跑 gdb
+docker run --rm -it \
+  -v /path/to/core.<pid>:/core:ro \
+  --entrypoint=gdb \
+  dingodatabase/dingo-store:abc1234-debug \
+    /opt/dingo-store/build/bin/dingodb_server /core
+
+# (gdb) thread apply all bt
+# 函数名 + 源码 file:line 全部恢复（dingo 代码经 .gnu_debuglink 解析 .debug）
+# glibc / libstdc++ 帧含函数名（容器内系统库 .symtab 可用）
+```
+
+`<tag>-debug` 镜像跟主镜像保证同一个 git commit（同一次
+`release-dockerhub.yml` run 产出，build-id 一致），不存在版本错配。
+
+### K8s 场景：ephemeral debug container
+
+线上 K8s pod 还活着想 attach 调试（不一定是 crash 后分析）：
+
+```bash
+# 用 sidecar 镜像作为 ephemeral debug container，共享目标 pod 的 PID namespace
+kubectl debug <victim-pod> \
+  --image=dingodatabase/dingo-store:<tag>-debug \
+  --target=<victim-container> \
+  --share-processes \
+  -it -- /bin/bash
+
+# 进入 ephemeral 容器后：
+gdb -p <victim-dingodb_server-pid>     # live attach
+# 或对 core 文件
+gdb /opt/dingo-store/build/bin/dingodb_server /path/to/core
+```
+
+### Fallback：要在 host 跑 gdb 的话
+
+如果 host 已经有 gdb 配置、SRE 习惯 host 调试，可以拷 `.debug` 文件
+出来到 stripped binary 旁边：
+
+```bash
+cid=$(docker create dingodatabase/dingo-store:<tag>-debug)
+docker cp $cid:/opt/dingo-store/build/bin/dingodb_server.debug ./
+docker rm $cid
+
+# host 上 gdb 经 .gnu_debuglink 自动找到同目录下的 .debug 文件
+gdb /opt/dingo-store/build/bin/dingodb_server core.<pid>
+```
+
+但 host 上 glibc 不一定跟容器内 glibc 版本一致，glibc 帧的函数名
+可能解不出来（要装 `glibc-debuginfo` 包），dingo 代码部分则正常。
+**推荐优先用容器内 gdb 方案**，host 兜底仅在不能跑 docker 时使用。
+
+## 本地调试
+
+开发者在本地直接 `cmake --build` 出来的 binary 跟 CI 一样是
+`RelWithDebInfo`，`.debug_*` 段就在 binary 本身里，gdb 不需要额外
+配置就能用。要在本地复现 CI 的 strip 流程：
+
+```bash
+cd build/bin
+for bin in dingodb_server dingodb_cli dingodb_br dingodb_client; do
+  objcopy --only-keep-debug "$bin" "$bin.debug"
+  objcopy --strip-debug     "$bin"
+  objcopy --add-gnu-debuglink="$bin.debug" "$bin"
+done
+
+# Round-trip 自检：addr2line 应该能通过 .debug 反向定位到源码行号
+addr_main=$(nm dingodb_server | awk '/ T main$/{print "0x"$1}')
+addr2line -e dingodb_server -f -C "$addr_main"
+# 预期输出：main / src/server/main.cc:520
+```
+
+把 `$bin.debug` 文件移走再跑 addr2line，应该看到输出退化为 `??:?`；
+移回来恢复正常。这条来回测试确认 `.gnu_debuglink` 链路真的在工作，
+不是 gdb 在用 binary 里残留的什么旧符号瞒过去。
+
+## 常见陷阱
+
+1. **缺 build-id**。`objcopy --add-gnu-debuglink` 不依赖
+   `.note.gnu.build-id`，但下游工具链（debuginfod、各发行版的
+   split-debuginfo 流程）需要这个 section 来唯一识别 binary。CI 通过
+   `readelf -n | grep 'Build ID'` 强制校验，缺则 fail。如果用自定义
+   toolchain 编译，确保 `LDFLAGS` 含 `-Wl,--build-id=sha1`。
+
+2. **CRC mismatch**。`.gnu_debuglink` section 里塞了 `.debug` 文件的
+   CRC32 校验值。如果 `.debug` 文件被修改、重 build 或跟主 binary
+   不同步，gdb 会静默忽略它（带 "CRC mismatch" warning）。永远成对
+   重新生成。`objcopy` 三步固定顺序：`--only-keep-debug` →
+   `--strip-debug` → `--add-gnu-debuglink`，反过来不行。
+
+3. **`.debug` 不能跨 commit 用**。commit X build 出来的 `.debug` 文件
+   对 commit Y 的 binary 没用——build-id 不同，CRC 也对不上。永远
+   按 `<tag>` 配对使用主镜像和 `<tag>-debug` 镜像。
+
+4. **gdb 找不到 `.debug` 文件**。默认 gdb 在 binary 同目录、`.debug/`
+   子目录、`/usr/lib/debug/` 下找。如果 `.debug` 放在别的位置，可以
+   在 `~/.gdbinit` 加 `set debug-file-directory /path/to/dir`，或者
+   命令行加 `-iex 'set debug-file-directory /path'`。


### PR DESCRIPTION
## Motivation

`dingodatabase/dingo-store:latest` is currently **3.04 GB compressed / 10.7 GB uncompressed**. The dominant cost is DWARF debug info: **~91% of binary size** (2.5 GB of 2.78 GB across the 4 `dingodb_*` binaries) comes from switching CI build type from `Release` to `RelWithDebInfo` in 6b8f0262 (Sep 2025).

This PR **keeps the debug info** — but moves it out of the runtime image into a sidecar `:<tag>-debug` image, following the standard **Debian `-dbgsym` / RHEL `-debuginfo`** packaging pattern that the GNU toolchain (`objcopy --add-gnu-debuglink`) is specifically designed for.

## Effect

Locally verified on commit `729a6880`:

| Binary | Before strip | After strip | Reduction |
|---|---|---|---|
| `dingodb_server` | 1085 MB | **87 MB** | 92% |
| `dingodb_cli` | 743 MB | **65 MB** | 91% |
| `dingodb_br` | 519 MB | **39 MB** | 92% |
| `dingodb_client` | 432 MB | **53 MB** | 88% |
| **Total** | **2778 MB** | **244 MB** | **91%** |

Image-level (locally verified end-to-end against `729a6880`):

| Image | Before | After | Reduction |
|---|---|---|---|
| `dingo-store:<tag>` | 3020 MB compressed / 10.7 GB uncompressed | **91 MB compressed / 379 MB uncompressed** | **-97% / -96%** |
| `dingo-store:<tag>-debug` (new sidecar, includes gdb + 1.3 GB DWARF) | – | 881 MB compressed / 3.02 GB uncompressed | – |

The `:<tag>` image now sits well under YugabyteDB (405 MB compressed) and
TiKV (763 MB compressed), the most directly comparable C++ multi-binary
DB projects. The combined effect of (a) strip + .gnu_debuglink and
(b) multi-stage build dropping the build toolchain out of the runtime
image is what brings the headline number down to 91 MB compressed.

## Why split-debuginfo instead of just stripping?

Two ends of the trade-off:

| Approach | `:latest` size | Crash debuggability |
|---|---|---|
| Keep current `RelWithDebInfo` everywhere | 3 GB | ✅ gdb sees everything |
| Strip aggressively, discard `.debug` | ~1 GB | ❌ `??:?` in backtrace, function names lost |
| **This PR: strip + sidecar `.debug` image** | **~1 GB** | ✅ gdb fully recovers via `.gnu_debuglink` + build-id |

The `.gnu_debuglink` + build-id mechanism is **the standard GNU/Linux split-debuginfo workflow**. It's what `dh_strip` (Debian) and `find-debuginfo.sh` (RHEL/Fedora) do internally. gdb, addr2line, perf, and elfutils all support it out of the box.

## Changes

**`ci_rocky8.yml` is intentionally left untouched** so it stays a pure
build-verification CI for every PR. All release-specific packaging
(strip, debug-info split, repack, sidecar image build) is consolidated
inside the existing `release-dockerhub.yml`, internally split into two
jobs flowing via `needs`:

```
ci_rocky8.yml      ────►  release-dockerhub.yml
(pure build CI,    workflow_run  ┌─────────────────────────────────┐
 unchanged)                       │ job: prepare_release_artifacts  │
                                  │   strip + repack + job outputs  │
                                  │           │ needs               │
                                  │           ▼                     │
                                  │ job: build_and_push_images      │
                                  │   docker build + push x 2       │
                                  └─────────────────────────────────┘
```

Keeping both jobs in a single workflow means **all artifacts stay within
one workflow run** and flow between jobs via the same-run artifact
namespace + `needs.<job>.outputs`. There is no cross-`workflow_run`
artifact lookup, so no chance of two release runs racing on the
"latest successful run" lookup of `dawidd6/action-download-artifact`.

### 1. `.github/workflows/release-dockerhub.yml`

Rewritten end-to-end:

- **Job 1 `prepare_release_artifacts`**:
  - `if: workflow_run.conclusion == 'success' && workflow_run.event != 'pull_request'` — single, expressive PR filter at the workflow boundary.
  - Downloads all 5 artifacts from CMake_rocky8 via `actions/download-artifact@v4` + `run-id` + `github-token` (requires `permissions: actions: read`).
  - For each `dingodb_*` binary, verifies `.note.gnu.build-id` is present (fail fast if missing — `.gnu_debuglink` and any future debuginfod workflow depend on it) and runs the standard three-step pipeline:

    ```bash
    objcopy --only-keep-debug "$bin" "$bin.debug"
    objcopy --strip-debug     "$bin"
    objcopy --add-gnu-debuglink="$bin.debug" "$bin"
    ```

  - Repacks `dingo-store.tar.gz` (stripped binaries) and produces a separate `dingo-store-debug.tar.gz` (4 `.debug` files), upload both as in-run artifacts.
  - Reads metadata files (`branch_name`, `commit_id`, `event`, `tag_name`) and exposes them as **job outputs** — no need to re-upload them as artifacts.

- **Job 2 `build_and_push_images`** (`needs: prepare_release_artifacts`):
  - `if: needs.prepare_release_artifacts.outputs.event != 'pull_request'` — defense in depth against malformed upstream metadata.
  - Downloads the two tarballs via `actions/download-artifact@v4` with **no `run-id`** — defaults to the current workflow run, so the artifacts are guaranteed to come from this specific Job 1 execution.
  - Resolves image tags from `needs.<job>.outputs.*` (replaces the previous chain of 4 download steps + 4 env config steps).
  - Two `docker/metadata-action` invocations: one for the main image, one with `flavor: suffix=-debug,onlatest=true` for the sidecar.
  - Two `docker/build-push-action` invocations: main runtime image + debug sidecar.

### 2. `docker/Dockerfile.debug` (new file)

Sidecar `FROM dingodatabase/dingo-store:${STORE_TAG}` extending the
runtime image with:

- `gdb`, `tar`, `gzip` (the runtime image's `rockylinux:8-minimal` base
  doesn't ship them by default).
- The four `dingodb_*.debug` DWARF files placed next to each stripped
  binary at `/opt/dingo-store/build/bin/`.

SREs can drop into a one-line workflow with no host-side debug tooling
required (see SRE workflow section).

### 3. `docker/Dockerfile` (rewritten as multi-stage + minimal runtime base)

Replaces the previous single-stage build that extended
`dingo-base:rocky8` (a build environment carrying gcc-toolset-13,
boost-devel, openssl-devel, libaio-devel, ...) with a two-stage layout:

- **Builder stage**: `FROM dingo-base:rocky8` — same image that
  `ci_rocky8.yml` already uses, guaranteeing glibc / libstdc++ ABI
  compatibility with the stripped binary.
- **Runtime stage**: `FROM rockylinux:8-minimal` (~140 MB) +
  `microdnf install libstdc++ procps-ng findutils tzdata net-tools iproute`
  — only the shared libraries `ldd dingodb_server` actually requires
  (most heavy deps like brpc/braft/rocksdb/boost/openssl/MKL are
  statically linked).
- `COPY --from=builder /opt/dingo-store /opt/dingo-store` brings the
  release tree into the final stage without any build artifacts.

End result: 91 MB compressed image with no behavioral change vs upstream
(cluster boots, raft elects, heartbeats flow — verified locally).

### 4. `docs/debug-symbols.md` (new) + `README.md` link

New operations guide covering:

- **Why split debug symbols** — motivation and the size trade-off.
- **How it works** — `.gnu_debuglink` + `.note.gnu.build-id` mechanics; the three-step `objcopy` pipeline.
- **How images are published to Docker Hub** — the two-stage workflow (`CMake_rocky8` build → `Release-Dockerhub` 2-job pipeline), trigger conditions, tag rules, and a NOTE that tag publishing requires `on.push.tags:` to be added to `ci_rocky8.yml` (currently not wired).
- **SRE workflow** — five-step crash analysis using the `:<tag>-debug` sidecar.
- **Local debugging** — reproducing the strip pipeline on a developer checkout.
- **Common pitfalls** — missing build-id, CRC mismatch, cross-commit `.debug` reuse, gdb search paths.

`README.md` adds a short "Debug Symbols" subsection under "How to build"
pointing at the new doc.

## SRE workflow

```bash
# 1. Read build-id from the stripped binary
readelf -n /opt/dingo-store/build/bin/dingodb_server | grep 'Build ID'

# 2. Pull the matching debug sidecar (same tag suffixed with -debug)
docker pull dingodatabase/dingo-store:<tag>-debug
cid=$(docker create dingodatabase/dingo-store:<tag>-debug)
docker cp $cid:/opt/dingo-store/build/bin/dingodb_server.debug ./
docker rm $cid

# 3. gdb auto-finds the .debug file via the .gnu_debuglink section
gdb -ex 'set debug-file-directory .' \
    /opt/dingo-store/build/bin/dingodb_server \
    /path/to/core
```

The matching `<tag>-debug` image is guaranteed to share the same git
commit as the production tag (both are produced by the same
`release-dockerhub.yml` run from the same build-id binaries), so no
version mismatch is possible.

## Verification

Locally verified on `729a6880` against a binary built with the current CI flags (`-DCMAKE_BUILD_TYPE=RelWithDebInfo -DTHIRD_PARTY_BUILD_TYPE=RelWithDebInfo -DWITH_DISKANN=ON -DWITH_MKL=ON`):

1. **objcopy three-step pipeline**: 2796 MB → 244 MB total across 4 binaries.
2. **`addr2line` round-trip**: `0x5989d0` → `main → src/server/main.cc:520` with `.debug` present; degrades to `??:?` when `.debug` removed; restores when put back. Confirms `.gnu_debuglink` is doing real work and not silently failing.
3. **Mini-cluster**: stripped `dingodb_server` boots, raft single-node election succeeds (`term=2, OnLeaderStart`), store registers and heartbeats for 30s with no errors. No functional regression.
4. **Live core dump**: `gcore` on running stripped binary produces a 7.1 GB core; gdb opens it with `.debug` present and shows full 181-thread backtrace.

GitHub Actions invariants verified against documentation:

- `actions/download-artifact@v4` with no `run-id` and no `github-token` defaults to the current workflow run — Job 2 downloads from Job 1's uploads without cross-run lookup.
- Cross-workflow downloads (Job 1) require `github-token` + `run-id` + `permissions: actions: read` — all set explicitly on Job 1.
- Job outputs are limited to 1 MB per job, 50 MB total per workflow run; the four metadata strings are well under this (a few hundred bytes total).

## Followup PRs (out of scope here)

To keep this PR small and easy to review, two larger optimizations are deferred:

1. **Multi-stage Dockerfile + minimal runtime base** (e.g. `rockylinux:9-minimal`): the current `docker/Dockerfile` extends `dingo-base:rocky8`, which carries the full build toolchain (`gcc-toolset-13`, `boost-devel`, ...) into the runtime image. Moving build into a builder stage and only `COPY --from=builder` the runtime artifacts would drop the image to ~400-500 MB (the YugabyteDB / Vitess-lite range).
2. **Split server / tools images**: `dingodb_cli` / `dingodb_br` / `dingodb_client` are operational tools that don't need to ship with the production server image. Moving them to a `dingo-store-tools` companion image would drop the server image further (Vitess-style "by use case" split).

These will be filed as separate PRs once this PR lands and the build-id / .debug pipeline is stable on `main`.
