### PR TITLE
[ci] Upgrade gcc-13 in ci_ubuntu to fix template scope-lookup bug

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -34,6 +34,24 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: git submodule update --init --recursive --progress
 
+    # The dingo-store-ubuntu-22.04-dev:eureka image ships with the original
+    # gcc-13.1.0-8ubuntu1~22.04 backport, which has a template scope-lookup
+    # bug that fails to resolve qualified-name typedefs (e.g. key_type) in
+    # out-of-class member function definitions. This causes errors like:
+    #   src/metrics/dingo_bvar.h:411:96: error: invalid use of incomplete
+    #   type 'class dingodb::DingoMultiDimension<T>'
+    # The bug is fixed in gcc-13.3.x (Rocky's gcc-toolset-13.3.1 builds the
+    # same source tree cleanly). Pull the newer gcc-13 from the
+    # ubuntu-toolchain-r/test PPA before configuring CMake.
+    - name: Upgrade gcc-13 to fix template scope-lookup bug
+      run: |
+        apt-get update
+        apt-get install -y software-properties-common
+        add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        apt-get update
+        apt-get install -y --only-upgrade gcc-13 g++-13
+        gcc-13 --version | head -1
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type


### PR DESCRIPTION
## Motivation

`CMake_ubuntu` workflow has been failing on every push to `main` for months — 10+ consecutive failures spanning unrelated commits (2026-04-07 through 2026-05-15). The error is always the same:

```
src/metrics/dingo_bvar.h:411:96: error: invalid use of incomplete type 'class dingodb::DingoMultiDimension<T>'
src/metrics/dingo_bvar.h:420:87: error: 'key_type' does not name a type; did you mean 'key_t'?
... (8 more)
```

## Root cause

| Build env | GCC | C++ std | Result |
|---|---|---|---|
| `ci_ubuntu` (`dingo-store-ubuntu-22.04-dev:eureka`) | **13.1.0** (Ubuntu 22.04 backport, 2023-04) | C++17 | ❌ FAIL |
| `ci_rocky9` (`gcc-toolset-13`) | **13.3.1** (Red Hat, 2024-06) | C++17 | ✅ SUCCESS |
| `ci_rocky8` (`gcc-toolset-13`) | 13.3.1 | C++23 | ✅ SUCCESS |

GCC 13.1.0 has a template scope-lookup bug. The compiler should auto-enter the class scope after parsing a qualified member-function name and resolve `key_type` from there:

```cpp
template <typename T>
class DingoMultiDimension : public bvar::MVariable<...> {
 public:
  typedef std::list<std::string> key_type;       // line 47, in class
  // ...
};
// ... line 411, out-of-class member definition:
template <typename T>
inline void DingoMultiDimension<T>::make_dump_key(
    std::ostream& os,
    const key_type& labels_value,                // ← 13.1.0 can't resolve
    ...) { ... }
```

The same source builds cleanly under `gcc-toolset-13.3.1` on both Rocky 8 and Rocky 9. The bug is fixed in GCC 13.3+.

## Fix

Pull newer `gcc-13` / `g++-13` from `ubuntu-toolchain-r/test` PPA before configuring CMake. Adds ~30 seconds to a 22+ minute build. No source-code changes; `dingo_bvar.h` is standard-conformant.

## Out of scope (future work)

Rebuilding the dev base image `dingo-store-ubuntu-22.04-dev:eureka` with newer GCC pre-installed (or switching to Ubuntu 24.04 which defaults to gcc-13.2+) would be a more permanent fix and avoid the 30s per-CI cost. That requires coordinated dev-image rebuild + dockerhub push outside this repo's CI, so deferred.

## How this was found

Diagnosed while preparing #1473 (dingo-store image shrinking, merged in `21ace789`). All Rocky variants passed; only Ubuntu failed with this error. Rocky and Ubuntu both default to C++17 here, so the difference is purely the GCC patch level (13.1.0 vs 13.3.1).
