### PR TITLE
[fix][docker] ubuntu22 dev base from stale ubuntu2204 to ubuntu2204-store

### DIFF
--- a/docker/ubuntu22/Dockerfile
+++ b/docker/ubuntu22/Dockerfile
@@ -1,5 +1,5 @@
 # FROM ubuntu:22.04
-FROM dingodatabase/dingo-eureka:ubuntu2204
+FROM dingodatabase/dingo-eureka:ubuntu2204-store
 
 ENV TZ=Asia/Shanghai \
     DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Motivation

`CMake_ubuntu` workflow has been failing on every push to main since commit dccb6eb9 (2025-11-17, "Fixed brpc interface changes"), which adapted `dingo_bvar.h` to brpc's now-template `bvar::MVariable<T>`. Compile errors look like template scope-lookup failures, but the underlying cause is the base image: `dingo-store-ubuntu-22.04-dev:eureka` ships an old brpc whose `MVariable` is still a non-template class.

## Root cause

`docker/ubuntu22/Dockerfile` pulls `dingodatabase/dingo-eureka:ubuntu2204`, a tag last pushed 2025-01-21 — 16 months stale. The active upstream workflow `ubuntu2204-store.yml` in `dingodb/dingo-eureka` pushes a different tag `ubuntu2204-store` (latest 2026-04-15, brpc 1.16.0 with template `MVariable`). Rocky's Dockerfiles already use the `-store` suffix:

| Dockerfile                | base tag                    | last push   |
|---------------------------|-----------------------------|-------------|
| `docker/rocky8/Dockerfile`  | `dingo-eureka:rocky8-store`   | 2026-04-15  |
| `docker/rocky9/Dockerfile`  | `dingo-eureka:rocky9-store`   | 2026-04-15  |
| `docker/ubuntu22/Dockerfile`| `dingo-eureka:ubuntu2204`     | 2025-01-21  | ← stale orphan |

The ubuntu Dockerfile was simply not renamed when the eureka repo adopted the \`-store\` suffix.

## Fix

One-line: switch to \`ubuntu2204-store\`.

## Followup required from maintainer

This PR alone does not unblock \`CMake_ubuntu\`. The CI job uses \`container: dingodatabase/dingo-store-ubuntu-22.04-dev:eureka\`, which is the *built* dev image (not built from source per-CI). After this PR merges, please run on a build host:

\`\`\`
docker build docker/ubuntu22/ -t dingodatabase/dingo-store-ubuntu-22.04-dev:eureka
docker push dingodatabase/dingo-store-ubuntu-22.04-dev:eureka
\`\`\`

This refreshes the dev image with the new brpc and unblocks the workflow for everyone. Replaces #1474 (gcc patch-level was a wrong diagnosis; local docker reproduction with gcc-13.4.0 from PPA still fails identically).