### PR TITLE
[feat][store] Add lock collection mode to TxnScan.

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -271,9 +271,10 @@ class Engine : public std::enable_shared_from_this<Engine> {
     virtual butil::Status TxnScan(std::shared_ptr<Context> ctx, int64_t start_ts, const pb::common::Range& range,
                                   int64_t limit, bool key_only, bool is_reverse,
                                   const std::set<int64_t>& resolved_locks, bool disable_coprocessor,
-                                  const pb::common::CoprocessorV2& coprocessor,
+                                  const pb::common::CoprocessorV2& coprocessor, bool enable_lock_collection,
                                   pb::store::TxnResultInfo& txn_result_info, std::vector<pb::common::KeyValue>& kvs,
-                                  bool& has_more, std::string& end_scan_key) = 0;
+                                  std::vector<pb::store::TxnScanEntry>& entries, bool& has_more,
+                                  std::string& end_scan_key) = 0;
     virtual butil::Status TxnScanLock(std::shared_ptr<Context> ctx, int64_t min_lock_ts, int64_t max_lock_ts,
                                       const pb::common::Range& range, int64_t limit,
                                       std::vector<pb::store::LockInfo>& lock_infos, bool& has_more,

--- a/src/engine/mono_store_engine.cc
+++ b/src/engine/mono_store_engine.cc
@@ -617,11 +617,12 @@ butil::Status MonoStoreEngine::TxnReader::TxnBatchGet(std::shared_ptr<Context> c
 butil::Status MonoStoreEngine::TxnReader::TxnScan(
     std::shared_ptr<Context> ctx, int64_t start_ts, const pb::common::Range& range, int64_t limit, bool key_only,
     bool is_reverse, const std::set<int64_t>& resolved_locks, bool disable_coprocessor,
-    const pb::common::CoprocessorV2& coprocessor, pb::store::TxnResultInfo& txn_result_info,
-    std::vector<pb::common::KeyValue>& kvs, bool& has_more, std::string& end_scan_key) {
+    const pb::common::CoprocessorV2& coprocessor, bool enable_lock_collection,
+    pb::store::TxnResultInfo& txn_result_info, std::vector<pb::common::KeyValue>& kvs,
+    std::vector<pb::store::TxnScanEntry>& entries, bool& has_more, std::string& end_scan_key) {
   return TxnEngineHelper::Scan(ctx, ctx->Stream(), txn_reader_raw_engine_, ctx->IsolationLevel(), start_ts, range, limit,
-                               key_only, is_reverse, resolved_locks, disable_coprocessor, coprocessor, txn_result_info,
-                               kvs, has_more, end_scan_key);
+                                key_only, is_reverse, resolved_locks, disable_coprocessor, coprocessor,
+                                enable_lock_collection, txn_result_info, kvs, entries, has_more, end_scan_key);
 }
 
 butil::Status MonoStoreEngine::TxnReader::TxnScanLock(std::shared_ptr<Context> ctx, int64_t min_lock_ts,

--- a/src/engine/mono_store_engine.h
+++ b/src/engine/mono_store_engine.h
@@ -187,7 +187,8 @@ class MonoStoreEngine : public Engine {
     butil::Status TxnScan(std::shared_ptr<Context> ctx, int64_t start_ts, const pb::common::Range& range, int64_t limit,
                           bool key_only, bool is_reverse, const std::set<int64_t>& resolved_locks,
                           bool disable_coprocessor, const pb::common::CoprocessorV2& coprocessor,
-                          pb::store::TxnResultInfo& txn_result_info, std::vector<pb::common::KeyValue>& kvs,
+                          bool enable_lock_collection, pb::store::TxnResultInfo& txn_result_info,
+                          std::vector<pb::common::KeyValue>& kvs, std::vector<pb::store::TxnScanEntry>& entries,
                           bool& has_more, std::string& end_scan_key) override;
     butil::Status TxnScanLock(std::shared_ptr<Context> ctx, int64_t min_lock_ts, int64_t max_lock_ts,
                               const pb::common::Range& range, int64_t limit,

--- a/src/engine/raft_store_engine.cc
+++ b/src/engine/raft_store_engine.cc
@@ -630,11 +630,12 @@ butil::Status RaftStoreEngine::TxnReader::TxnBatchGet(std::shared_ptr<Context> c
 butil::Status RaftStoreEngine::TxnReader::TxnScan(
     std::shared_ptr<Context> ctx, int64_t start_ts, const pb::common::Range& range, int64_t limit, bool key_only,
     bool is_reverse, const std::set<int64_t>& resolved_locks, bool disable_coprocessor,
-    const pb::common::CoprocessorV2& coprocessor, pb::store::TxnResultInfo& txn_result_info,
-    std::vector<pb::common::KeyValue>& kvs, bool& has_more, std::string& end_scan_key) {
+    const pb::common::CoprocessorV2& coprocessor, bool enable_lock_collection,
+    pb::store::TxnResultInfo& txn_result_info, std::vector<pb::common::KeyValue>& kvs,
+    std::vector<pb::store::TxnScanEntry>& entries, bool& has_more, std::string& end_scan_key) {
   return TxnEngineHelper::Scan(ctx, ctx->Stream(), txn_reader_raw_engine_, ctx->IsolationLevel(), start_ts, range,
-                               limit, key_only, is_reverse, resolved_locks, disable_coprocessor, coprocessor,
-                               txn_result_info, kvs, has_more, end_scan_key);
+                                limit, key_only, is_reverse, resolved_locks, disable_coprocessor, coprocessor,
+                                enable_lock_collection, txn_result_info, kvs, entries, has_more, end_scan_key);
 }
 
 butil::Status RaftStoreEngine::TxnReader::TxnScanLock(std::shared_ptr<Context> ctx, int64_t min_lock_ts,

--- a/src/engine/raft_store_engine.h
+++ b/src/engine/raft_store_engine.h
@@ -235,7 +235,8 @@ class RaftStoreEngine : public Engine, public RaftControlAble {
     butil::Status TxnScan(std::shared_ptr<Context> ctx, int64_t start_ts, const pb::common::Range& range, int64_t limit,
                           bool key_only, bool is_reverse, const std::set<int64_t>& resolved_locks,
                           bool disable_coprocessor, const pb::common::CoprocessorV2& coprocessor,
-                          pb::store::TxnResultInfo& txn_result_info, std::vector<pb::common::KeyValue>& kvs,
+                          bool enable_lock_collection, pb::store::TxnResultInfo& txn_result_info,
+                          std::vector<pb::common::KeyValue>& kvs, std::vector<pb::store::TxnScanEntry>& entries,
                           bool& has_more, std::string& end_scan_key) override;
     butil::Status TxnScanLock(std::shared_ptr<Context> ctx, int64_t min_lock_ts, int64_t max_lock_ts,
                               const pb::common::Range& range, int64_t limit,

--- a/src/engine/storage.cc
+++ b/src/engine/storage.cc
@@ -1558,11 +1558,12 @@ butil::Status Storage::TxnBatchGet(std::shared_ptr<Context> ctx, int64_t start_t
 }
 
 butil::Status Storage::TxnScan(std::shared_ptr<Context> ctx, const pb::stream::StreamRequestMeta& req_stream_meta,
-                               int64_t start_ts, const pb::common::Range& range, int64_t limit, bool key_only,
-                               bool is_reverse, const std::set<int64_t>& resolved_locks,
-                               pb::store::TxnResultInfo& txn_result_info, std::vector<pb::common::KeyValue>& kvs,
-                               bool& has_more, std::string& end_scan_key, bool disable_coprocessor,
-                               const pb::common::CoprocessorV2& coprocessor) {
+                                int64_t start_ts, const pb::common::Range& range, int64_t limit, bool key_only,
+                                bool is_reverse, const std::set<int64_t>& resolved_locks, bool enable_lock_collection,
+                                pb::store::TxnResultInfo& txn_result_info, std::vector<pb::common::KeyValue>& kvs,
+                                std::vector<pb::store::TxnScanEntry>& entries, bool& has_more,
+                                std::string& end_scan_key, bool disable_coprocessor,
+                                const pb::common::CoprocessorV2& coprocessor) {
   auto status = ValidateLeader(ctx->RegionId());
   if (BAIDU_UNLIKELY(!status.ok())) {
     return status;
@@ -1586,7 +1587,7 @@ butil::Status Storage::TxnScan(std::shared_ptr<Context> ctx, const pb::stream::S
   auto reader = GetEngineTxnReader(ctx->StoreEngineType(), ctx->RawEngineType());
 
   status = reader->TxnScan(ctx, start_ts, range, limit, key_only, is_reverse, resolved_locks, disable_coprocessor,
-                           coprocessor, txn_result_info, kvs, has_more, end_scan_key);
+                            coprocessor, enable_lock_collection, txn_result_info, kvs, entries, has_more, end_scan_key);
   if (BAIDU_UNLIKELY(!status.ok())) {
     if (pb::error::EKEY_NOT_FOUND == status.error_code()) {
       // return OK if not found

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -82,8 +82,10 @@ class Storage {
                             std::vector<pb::common::KeyValue>& kvs);
   butil::Status TxnScan(std::shared_ptr<Context> ctx, const pb::stream::StreamRequestMeta& req_stream_meta,
                         int64_t start_ts, const pb::common::Range& range, int64_t limit, bool key_only, bool is_reverse,
-                        const std::set<int64_t>& resolved_locks, pb::store::TxnResultInfo& txn_result_info,
-                        std::vector<pb::common::KeyValue>& kvs, bool& has_more, std::string& end_scan_key,
+                        const std::set<int64_t>& resolved_locks, bool enable_lock_collection,
+                        pb::store::TxnResultInfo& txn_result_info,
+                        std::vector<pb::common::KeyValue>& kvs, std::vector<pb::store::TxnScanEntry>& entries,
+                        bool& has_more, std::string& end_scan_key,
                         bool disable_coprocessor, const pb::common::CoprocessorV2& coprocessor);
   butil::Status TxnScanLock(std::shared_ptr<Context> ctx, const pb::stream::StreamRequestMeta& req_stream_meta,
                             int64_t max_ts, const pb::common::Range& range, int64_t limit,

--- a/src/engine/txn_engine_helper.cc
+++ b/src/engine/txn_engine_helper.cc
@@ -551,7 +551,7 @@ butil::Status TxnIterator::Seek(const std::string &key) {
     return ret;
   }
 
-  while (value_.empty()) {
+  while (value_.empty() && !(lock_collection_enabled_ && IsCurrentKeyLocked())) {
     ret = InnerNext();
     if (ret.error_code() == pb::error::Errno::ETXN_SCAN_FINISH) {
       DINGO_LOG_IF(INFO, FLAGS_dingo_log_switch_txn_detail)
@@ -562,7 +562,7 @@ butil::Status TxnIterator::Seek(const std::string &key) {
       return ret;
     }
 
-    if (!value_.empty()) {
+    if (!value_.empty() || (lock_collection_enabled_ && IsCurrentKeyLocked())) {
       return butil::Status::OK();
     } else {
       DINGO_LOG_IF(INFO, FLAGS_dingo_log_switch_txn_detail)
@@ -576,6 +576,7 @@ butil::Status TxnIterator::Seek(const std::string &key) {
 }
 
 butil::Status TxnIterator::InnerSeek(const std::string &key) {
+  ClearCurrentLockInfo();
   key_.clear();
   value_.clear();
   last_lock_key_.clear();
@@ -665,7 +666,7 @@ butil::Status TxnIterator::Next() {
       return ret;
     }
 
-    if (!value_.empty()) {
+    if (!value_.empty() || (lock_collection_enabled_ && IsCurrentKeyLocked())) {
       return butil::Status::OK();
     } else {
       DINGO_LOG_IF(INFO, FLAGS_dingo_log_switch_txn_detail)
@@ -679,6 +680,7 @@ butil::Status TxnIterator::Next() {
 }
 
 butil::Status TxnIterator::InnerNext() {
+  ClearCurrentLockInfo();
   if (key_.empty()) {
     DINGO_LOG_IF(INFO, FLAGS_dingo_log_switch_txn_detail)
         << "[txn]Scan Next key_ is empty, scan is finished, start_ts: " << start_ts_ << ", seek_ts: " << seek_ts_;
@@ -984,6 +986,21 @@ butil::Status TxnIterator::GetCurrentValue() {
                          << ", isolation_level: " << isolation_level_ << ", start_ts: " << start_ts_
                          << ", seek_ts: " << seek_ts_ << ", lock_info: " << lock_info.ShortDebugString()
                          << ", txn_result_info: " << txn_result_info_.ShortDebugString();
+      if (lock_collection_enabled_) {
+        // Lock collection mode: record the lock as a locked entry instead of aborting the scan.
+        // Keep key_ pointing to the locked key so the caller can emit a locked TxnScanEntry.
+        current_lock_info_ = lock_info;
+        // Clear txn_result_info_ so that Valid() does not treat this as a hard conflict.
+        txn_result_info_ = pb::store::TxnResultInfo();
+        // Advance write_iter_ past this key when it points to the same user key.
+        // Only the == case needs handling: < means write_iter_ is already ahead,
+        // and > here implies !write_iter_->Valid() so no advance is possible.
+        if (last_write_key_ == last_lock_key_) {
+          GotoNextUserKeyInWriteIter(write_iter_, last_write_key_, last_write_key_, total_skipped_versions_);
+        }
+        value_.clear();
+        return butil::Status::OK();
+      }
       key_.clear();
       value_.clear();
       return butil::Status(pb::error::Errno::ETXN_LOCK_CONFLICT, "lock conflict");
@@ -1059,6 +1076,15 @@ bool TxnIterator::Valid(pb::store::TxnResultInfo &txn_result_info) {
 std::string TxnIterator::Key() { return key_; }
 
 std::string TxnIterator::Value() { return value_; }
+
+bool TxnIterator::IsCurrentKeyLocked() {
+  return lock_collection_enabled_ && !key_.empty() && !current_lock_info_.key().empty() &&
+         current_lock_info_.key() == key_;
+}
+
+pb::store::LockInfo TxnIterator::GetCurrentLockInfo() { return current_lock_info_; }
+
+void TxnIterator::ClearCurrentLockInfo() { current_lock_info_ = pb::store::LockInfo(); }
 
 bool TxnEngineHelper::CheckLockConflict(const pb::store::LockInfo &lock_info, pb::store::IsolationLevel isolation_level,
                                         int64_t start_ts, const std::set<int64_t> &resolved_locks,
@@ -1479,18 +1505,19 @@ butil::Status TxnEngineHelper::Scan(std::shared_ptr<Context> ctx, StreamPtr stre
                                     const pb::store::IsolationLevel &isolation_level, int64_t start_ts,
                                     const pb::common::Range &range, int64_t limit, bool key_only, bool is_reverse,
                                     const std::set<int64_t> &resolved_locks, bool disable_coprocessor,
-                                    const pb::common::CoprocessorV2 &coprocessor,
+                                    const pb::common::CoprocessorV2 &coprocessor, bool enable_lock_collection,
                                     pb::store::TxnResultInfo &txn_result_info, std::vector<pb::common::KeyValue> &kvs,
-                                    bool &has_more, std::string &end_scan_key) {
+                                    std::vector<pb::store::TxnScanEntry> &entries, bool &has_more,
+                                    std::string &end_scan_key) {
   BvarLatencyGuard bvar_guard(&g_txn_scan_latency);
 
   DINGO_LOG(INFO) << fmt::format(
       "[txn][{}] Scan start_ts: {} range: {} isolation_level: {} start_ts: {} limit: {} key_only: {} is_reverse: {} "
-      "resolved_locks size: {} disable_coprocessor: {} coprocessor: {} txn_result_info: {}, has_more: {}, "
+      "resolved_locks size: {} disable_coprocessor: {} coprocessor: {} enable_lock_collection: {} txn_result_info: {}, has_more: {}, "
       "end_scan_key: {}.",
       stream->StreamId(), start_ts, Helper::RangeToString(range), pb::store::IsolationLevel_Name(isolation_level),
       start_ts, limit, key_only, is_reverse, resolved_locks.size(), disable_coprocessor, coprocessor.ShortDebugString(),
-      txn_result_info.ShortDebugString(), has_more, Helper::StringToHex(end_scan_key));
+      enable_lock_collection, txn_result_info.ShortDebugString(), has_more, Helper::StringToHex(end_scan_key));
   uint64_t start_time = Helper::TimestampUs();
   if (isolation_level != pb::store::SnapshotIsolation && isolation_level != pb::store::ReadCommitted) {
     DINGO_LOG(ERROR) << fmt::format("[txn][{}] TxnScan invalid isolation_level: {}.", stream->StreamId(),
@@ -1501,6 +1528,10 @@ butil::Status TxnEngineHelper::Scan(std::shared_ptr<Context> ctx, StreamPtr stre
   if (!kvs.empty()) {
     return butil::Status(pb::error::Errno::EILLEGAL_PARAMTETERS, "kvs is not empty");
   }
+  if (!entries.empty()) {
+    return butil::Status(pb::error::Errno::EILLEGAL_PARAMTETERS, "entries is not empty");
+  }
+  bool lock_collection_enabled = enable_lock_collection && disable_coprocessor;
   auto tracker = ctx->Tracker();
   tracker->SetStartTs(start_ts);
 
@@ -1518,6 +1549,7 @@ butil::Status TxnEngineHelper::Scan(std::shared_ptr<Context> ctx, StreamPtr stre
       DINGO_LOG(ERROR) << s;
       return butil::Status(status.error_code(), s);
     }
+    iter->SetLockCollectionEnabled(lock_collection_enabled);
 
     uint64_t seek_start_time = Helper::TimestampUs();
     Tracker::RocksDBPerfContext seek_perf;
@@ -1560,6 +1592,15 @@ butil::Status TxnEngineHelper::Scan(std::shared_ptr<Context> ctx, StreamPtr stre
   TxnScanStreamStatePtr stream_state = std::dynamic_pointer_cast<TxnScanStreamState>(stream->StreamState());
   TxnIteratorPtr iter = stream_state->iter;
   CHECK(iter != nullptr) << fmt::format("[txn][{}] Scan stream_state->iter is nullptr.", stream->StreamId());
+  if (iter->LockCollectionEnabled() != lock_collection_enabled) {
+    std::string s = fmt::format(
+        "[txn][{}] Scan lock_collection_enabled changed in the same stream, previous: {} current: {}, start_ts: {} "
+        "range: {}.",
+        stream->StreamId(), iter->LockCollectionEnabled(), lock_collection_enabled, start_ts,
+        Helper::RangeToString(range));
+    DINGO_LOG(ERROR) << s;
+    return butil::Status(pb::error::Errno::EILLEGAL_PARAMTETERS, s);
+  }
 
   RawCoprocessor::StopChecker stop_checker = [&stream](size_t size, size_t bytes) -> bool {
     return stream->Check(size, bytes);
@@ -1589,54 +1630,117 @@ butil::Status TxnEngineHelper::Scan(std::shared_ptr<Context> ctx, StreamPtr stre
     uint64_t valid_result_time = Helper::TimestampUs();
     auto count = 0;
     RocksDBPerfGuard scan_perf_guard;
-    while (iter->Valid(txn_result_info)) {
-      uint64_t iter_time = Helper::TimestampUs();
-      auto key = iter->Key();
-      auto value = iter->Value();
 
-      pb::common::KeyValue kv;
-      kv.set_key(key);
-      if (!key_only) kv.set_value(value);
-      bytes += kv.ByteSizeLong();
-      kvs.push_back(std::move(kv));
+    if (lock_collection_enabled) {
+      // Lock collection mode: produce TxnScanEntry entries.
+      int64_t kv_count = 0;
+      int64_t lock_count = 0;
+      while (iter->Valid(txn_result_info)) {
+        uint64_t iter_time = Helper::TimestampUs();
+        auto key = iter->Key();
 
-      if (stop_checker(kvs.size(), bytes)) {
-        has_more = true;
-
-        DINGO_LOG_IF(INFO, FLAGS_dingo_log_switch_txn_detail) << fmt::format(
-            "[txn][{}] ScanLockInfo has_more: {} kv size: {} limit: {} max_scan_lock_limit: {} response_memory_size: "
-            "{} max_scan_memory_size: {}.",
-            stream->StreamId(), has_more, kvs.size(), limit, FLAGS_stream_message_max_limit_size, bytes,
-            FLAGS_stream_message_max_bytes);
-
-        break;
-      }
-
-      butil::Status status = iter->Next();
-      if (Helper::TimestampUs() - iter_time > FLAGS_txn_iterator_elapse_time_threshold_ms * 1000) {
-        DINGO_LOG_IF(INFO, FLAGS_dingo_log_switch_txn_detail) << fmt::format(
-            "[txn]Scan start_ts:{},  iter_next elapsed:{} us.", start_ts, Helper::TimestampUs() - iter_time);
-      }
-
-      count++;
-      if (!status.ok()) {
-        if (status.error_code() == pb::error::Errno::ETXN_LOCK_CONFLICT) {
-          DINGO_LOG(INFO) << fmt::format("[txn][{}] Scan Next meet lock conflict, start_ts: {} range: {}  status: {}.",
-                                         stream->StreamId(), start_ts, Helper::RangeToString(range),
-                                         status.error_str());
-
-          CHECK(!iter->Valid(txn_result_info)) << fmt::format(
-              "[txn][{}] Scan Next meet pb::error::Errno::ETXN_LOCK_CONFLICT, but iter->Valid = true. txn_result_info: "
-              "{}",
-              stream->StreamId(), txn_result_info.DebugString());
-          has_more = true;
-          return butil::Status::OK();
-
+        pb::store::TxnScanEntry entry;
+        if (iter->IsCurrentKeyLocked()) {
+          *entry.mutable_locked() = iter->GetCurrentLockInfo();
+          lock_count++;
         } else {
-          std::string s = fmt::format("[txn][{}] Scan iter->Next() failed, start_ts: {} range: {}  status: {}.",
-                                      stream->StreamId(), start_ts, Helper::RangeToString(range), status.error_str());
-          DINGO_LOG(ERROR) << s;
-          return butil::Status(status.error_code(), s);
+          entry.mutable_kv()->set_key(key);
+          if (!key_only) entry.mutable_kv()->set_value(iter->Value());
+          kv_count++;
+        }
+        bytes += entry.ByteSizeLong();
+        entries.push_back(std::move(entry));
+
+        // Count locked and kv entries together to cap the total response batch size.
+        if (stop_checker(entries.size(), bytes)) {
+          has_more = true;
+          DINGO_LOG_IF(INFO, FLAGS_dingo_log_switch_txn_detail)
+              << fmt::format("[txn][{}] Scan(lock_collection) has_more: {} entry size: {} bytes: {}.",
+                             stream->StreamId(), has_more, entries.size(), bytes);
+          break;
+        }
+
+        butil::Status status = iter->Next();
+        if (Helper::TimestampUs() - iter_time > FLAGS_txn_iterator_elapse_time_threshold_ms * 1000) {
+          DINGO_LOG_IF(INFO, FLAGS_dingo_log_switch_txn_detail)
+              << fmt::format("[txn]Scan start_ts:{},  iter_next elapsed:{} us.", start_ts,
+                             Helper::TimestampUs() - iter_time);
+        }
+
+        count++;
+        if (!status.ok()) {
+          if (status.error_code() == pb::error::Errno::ETXN_LOCK_CONFLICT) {
+            DINGO_LOG(ERROR) << fmt::format(
+                "[txn][{}] Scan(lock_collection) iter->Next() returned ETXN_LOCK_CONFLICT unexpectedly, start_ts: {} "
+                "range: {} status: {}.",
+                stream->StreamId(), start_ts, Helper::RangeToString(range), status.error_str());
+            return butil::Status(pb::error::Errno::EINTERNAL,
+                                 "unexpected lock conflict in lock collection mode");
+          } else {
+            std::string s = fmt::format(
+                "[txn][{}] Scan(lock_collection) iter->Next() failed, start_ts: {} range: {} status: {}.",
+                stream->StreamId(), start_ts, Helper::RangeToString(range), status.error_str());
+            DINGO_LOG(ERROR) << s;
+            return butil::Status(status.error_code(), s);
+          }
+        }
+      }
+      DINGO_LOG_IF(INFO, FLAGS_dingo_log_switch_txn_detail)
+          << fmt::format("[txn][{}] Scan(lock_collection) finished, total entries: {}, kv: {}, locked: {}.",
+                         stream->StreamId(), entries.size(), kv_count, lock_count);
+    } else {
+      // Original kvs mode.
+      while (iter->Valid(txn_result_info)) {
+        uint64_t iter_time = Helper::TimestampUs();
+        auto key = iter->Key();
+        auto value = iter->Value();
+
+        pb::common::KeyValue kv;
+        kv.set_key(key);
+        if (!key_only) kv.set_value(value);
+        bytes += kv.ByteSizeLong();
+        kvs.push_back(std::move(kv));
+
+        if (stop_checker(kvs.size(), bytes)) {
+          has_more = true;
+
+          DINGO_LOG_IF(INFO, FLAGS_dingo_log_switch_txn_detail) << fmt::format(
+              "[txn][{}] ScanLockInfo has_more: {} kv size: {} limit: {} max_scan_lock_limit: {} response_memory_size: "
+              "{} max_scan_memory_size: {}.",
+              stream->StreamId(), has_more, kvs.size(), limit, FLAGS_stream_message_max_limit_size, bytes,
+              FLAGS_stream_message_max_bytes);
+
+          break;
+        }
+
+        butil::Status status = iter->Next();
+        if (Helper::TimestampUs() - iter_time > FLAGS_txn_iterator_elapse_time_threshold_ms * 1000) {
+          DINGO_LOG_IF(INFO, FLAGS_dingo_log_switch_txn_detail)
+              << fmt::format("[txn]Scan start_ts:{},  iter_next elapsed:{} us.", start_ts,
+                             Helper::TimestampUs() - iter_time);
+        }
+
+        count++;
+        if (!status.ok()) {
+          if (status.error_code() == pb::error::Errno::ETXN_LOCK_CONFLICT) {
+            DINGO_LOG(INFO) << fmt::format(
+                "[txn][{}] Scan Next meet lock conflict, start_ts: {} range: {}  status: {}.",
+                stream->StreamId(), start_ts, Helper::RangeToString(range), status.error_str());
+
+            CHECK(!iter->Valid(txn_result_info)) << fmt::format(
+                "[txn][{}] Scan Next meet pb::error::Errno::ETXN_LOCK_CONFLICT, but iter->Valid = true. "
+                "txn_result_info: "
+                "{}",
+                stream->StreamId(), txn_result_info.DebugString());
+            has_more = true;
+            return butil::Status::OK();
+
+          } else {
+            std::string s = fmt::format("[txn][{}] Scan iter->Next() failed, start_ts: {} range: {}  status: {}.",
+                                        stream->StreamId(), start_ts, Helper::RangeToString(range), status.error_str());
+            DINGO_LOG(ERROR) << s;
+            return butil::Status(status.error_code(), s);
+          }
         }
       }
     }
@@ -1645,8 +1749,8 @@ butil::Status TxnEngineHelper::Scan(std::shared_ptr<Context> ctx, StreamPtr stre
 
     if (Helper::TimestampUs() - valid_result_time > FLAGS_txn_iterator_elapse_time_threshold_ms * 1000) {
       DINGO_LOG_IF(INFO, FLAGS_dingo_log_switch_txn_detail)
-          << fmt::format("[txn]Scan start_ts:{}, kvs.size:{}, count:{}, valid_result_time elapsed:{} us.", start_ts,
-                         kvs.size(), count, Helper::TimestampUs() - valid_result_time);
+          << fmt::format("[txn]Scan start_ts:{}, kvs.size:{}, entries.size:{}, count:{}, valid_result_time elapsed:{} us.",
+                         start_ts, kvs.size(), entries.size(), count, Helper::TimestampUs() - valid_result_time);
     }
   }
   if (iter->Valid(txn_result_info)) {
@@ -1654,6 +1758,14 @@ butil::Status TxnEngineHelper::Scan(std::shared_ptr<Context> ctx, StreamPtr stre
     butil::Status status = iter->Next();
     if (!status.ok()) {
       if (status.error_code() == pb::error::Errno::ETXN_LOCK_CONFLICT) {
+        if (lock_collection_enabled) {
+          DINGO_LOG(ERROR) << fmt::format(
+              "[txn][{}] Scan(lock_collection) end_key Next returned ETXN_LOCK_CONFLICT unexpectedly, start_ts: {} "
+              "range: {} status: {}.",
+              stream->StreamId(), start_ts, Helper::RangeToString(range), status.error_str());
+          return butil::Status(pb::error::Errno::EINTERNAL,
+                               "unexpected lock conflict in lock collection mode");
+        }
         DINGO_LOG(INFO) << fmt::format("[txn][{}] Scan Next meet lock conflict, start_ts: {} range: {}  status: {}.",
                                        stream->StreamId(), start_ts, Helper::RangeToString(range), status.error_str());
 

--- a/src/engine/txn_engine_helper.cc
+++ b/src/engine/txn_engine_helper.cc
@@ -1077,12 +1077,12 @@ std::string TxnIterator::Key() { return key_; }
 
 std::string TxnIterator::Value() { return value_; }
 
-bool TxnIterator::IsCurrentKeyLocked() {
+bool TxnIterator::IsCurrentKeyLocked() const {
   return lock_collection_enabled_ && !key_.empty() && !current_lock_info_.key().empty() &&
          current_lock_info_.key() == key_;
 }
 
-pb::store::LockInfo TxnIterator::GetCurrentLockInfo() { return current_lock_info_; }
+const pb::store::LockInfo& TxnIterator::GetCurrentLockInfo() const { return current_lock_info_; }
 
 void TxnIterator::ClearCurrentLockInfo() { current_lock_info_ = pb::store::LockInfo(); }
 
@@ -1530,6 +1530,10 @@ butil::Status TxnEngineHelper::Scan(std::shared_ptr<Context> ctx, StreamPtr stre
   }
   if (!entries.empty()) {
     return butil::Status(pb::error::Errno::EILLEGAL_PARAMTETERS, "entries is not empty");
+  }
+  if (enable_lock_collection && !disable_coprocessor) {
+    return butil::Status(pb::error::Errno::EILLEGAL_PARAMTETERS,
+                         "lock collection does not support coprocessor");
   }
   bool lock_collection_enabled = enable_lock_collection && disable_coprocessor;
   auto tracker = ctx->Tracker();

--- a/src/engine/txn_engine_helper.h
+++ b/src/engine/txn_engine_helper.h
@@ -101,6 +101,13 @@ class TxnIterator {
   std::string GetLastLockKey() { return last_lock_key_; }
   std::string GetLastWriteKey() { return last_write_key_; }
 
+  // Lock collection support.
+  void SetLockCollectionEnabled(bool enable) { lock_collection_enabled_ = enable; }
+  bool LockCollectionEnabled() const { return lock_collection_enabled_; }
+  bool IsCurrentKeyLocked();
+  pb::store::LockInfo GetCurrentLockInfo();
+  void ClearCurrentLockInfo();
+
   const int64_t GetSkippedVersions() { return total_skipped_versions_; }
 
   void ResetSkippedVersions() { total_skipped_versions_ = 0; }
@@ -142,6 +149,10 @@ class TxnIterator {
   // The resolved locks are used to check the lock conflict.
   // If the lock is resolved, there will not be a conflict for provided resolved_locks.
   std::set<int64_t> resolved_locks_;
+
+  // Lock collection state.
+  bool lock_collection_enabled_{false};
+  pb::store::LockInfo current_lock_info_;
 };
 using TxnIteratorPtr = std::shared_ptr<TxnIterator>;
 
@@ -165,8 +176,10 @@ class TxnEngineHelper {
                             const pb::store::IsolationLevel &isolation_level, int64_t start_ts,
                             const pb::common::Range &range, int64_t limit, bool key_only, bool is_reverse,
                             const std::set<int64_t> &resolved_locks, bool disable_coprocessor,
-                            const pb::common::CoprocessorV2 &coprocessor, pb::store::TxnResultInfo &txn_result_info,
-                            std::vector<pb::common::KeyValue> &kvs, bool &has_more, std::string &end_scan_key);
+                            const pb::common::CoprocessorV2 &coprocessor, bool enable_lock_collection,
+                            pb::store::TxnResultInfo &txn_result_info, std::vector<pb::common::KeyValue> &kvs,
+                            std::vector<pb::store::TxnScanEntry> &entries, bool &has_more,
+                            std::string &end_scan_key);
 
   // txn write functions
   static butil::Status DoTxnCommit(RawEnginePtr raw_engine, std::shared_ptr<Engine> raft_engine,

--- a/src/engine/txn_engine_helper.h
+++ b/src/engine/txn_engine_helper.h
@@ -104,8 +104,8 @@ class TxnIterator {
   // Lock collection support.
   void SetLockCollectionEnabled(bool enable) { lock_collection_enabled_ = enable; }
   bool LockCollectionEnabled() const { return lock_collection_enabled_; }
-  bool IsCurrentKeyLocked();
-  pb::store::LockInfo GetCurrentLockInfo();
+  bool IsCurrentKeyLocked() const;
+  const pb::store::LockInfo& GetCurrentLockInfo() const;
   void ClearCurrentLockInfo();
 
   const int64_t GetSkippedVersions() { return total_skipped_versions_; }

--- a/src/server/document_service.cc
+++ b/src/server/document_service.cc
@@ -1248,11 +1248,13 @@ void DoTxnScanDocument(StoragePtr storage, google::protobuf::RpcController* cont
   ctx->SetStoreEngineType(region->GetStoreEngineType());
 
   std::vector<pb::common::KeyValue> kvs;
+  std::vector<pb::store::TxnScanEntry> entries;
   bool has_more = false;
   std::string end_key{};
 
   status = storage->TxnScan(ctx, request->stream_meta(), request->start_ts(), correction_range, request->limit(),
-                            request->key_only(), request->is_reverse(), resolved_locks, txn_result_info, kvs, has_more,
+                            request->key_only(), request->is_reverse(), resolved_locks, false,
+                            txn_result_info, kvs, entries, has_more,
                             end_key, !request->has_coprocessor(), request->coprocessor());
   if (!status.ok()) {
     ServiceHelper::SetError(response->mutable_error(), status.error_code(), status.error_str());

--- a/src/server/document_service.cc
+++ b/src/server/document_service.cc
@@ -1166,6 +1166,10 @@ static butil::Status ValidateTxnScanRequestIndex(const pb::store::TxnScanRequest
   if (request->start_ts() < 0) {
     return butil::Status(pb::error::EILLEGAL_PARAMTETERS, "param start_ts is invalid");
   }
+  if (request->enable_lock_collection()) {
+    return butil::Status(pb::error::EILLEGAL_PARAMTETERS,
+                         "lock collection is not supported for document txn scan");
+  }
 
   auto status = ServiceHelper::ValidateRegionEpoch(request->context().region_epoch(), region);
   if (!status.ok()) {

--- a/src/server/index_service.cc
+++ b/src/server/index_service.cc
@@ -2531,11 +2531,13 @@ void DoTxnScanVector(StoragePtr storage, google::protobuf::RpcController* contro
   ctx->SetStoreEngineType(region->GetStoreEngineType());
 
   std::vector<pb::common::KeyValue> kvs;
+  std::vector<pb::store::TxnScanEntry> entries;
   bool has_more = false;
   std::string end_key{};
 
   status = storage->TxnScan(ctx, request->stream_meta(), request->start_ts(), correction_range, request->limit(),
-                            request->key_only(), request->is_reverse(), resolved_locks, txn_result_info, kvs, has_more,
+                            request->key_only(), request->is_reverse(), resolved_locks, false,
+                            txn_result_info, kvs, entries, has_more,
                             end_key, !request->has_coprocessor(), request->coprocessor());
   if (!status.ok()) {
     ServiceHelper::SetError(response->mutable_error(), status.error_code(), status.error_str());

--- a/src/server/index_service.cc
+++ b/src/server/index_service.cc
@@ -2449,6 +2449,10 @@ static butil::Status ValidateTxnScanRequestIndex(const pb::store::TxnScanRequest
   if (request->start_ts() < 0) {
     return butil::Status(pb::error::EILLEGAL_PARAMTETERS, "param start_ts is invalid");
   }
+  if (request->enable_lock_collection()) {
+    return butil::Status(pb::error::EILLEGAL_PARAMTETERS,
+                         "lock collection is not supported for vector txn scan");
+  }
 
   auto status = ServiceHelper::ValidateRegionEpoch(request->context().region_epoch(), region);
   if (!status.ok()) {

--- a/src/server/store_service.cc
+++ b/src/server/store_service.cc
@@ -1841,11 +1841,15 @@ void DoTxnScan(StoragePtr storage, google::protobuf::RpcController* controller,
   ctx->SetStoreEngineType(region->GetStoreEngineType());
 
   std::vector<pb::common::KeyValue> kvs;
+  std::vector<pb::store::TxnScanEntry> entries;
   bool has_more = false;
   std::string end_key{};
 
+  bool enable_lock_collection = request->enable_lock_collection();
+
   status = storage->TxnScan(ctx, request->stream_meta(), request->start_ts(), correction_range, request->limit(),
-                            request->key_only(), request->is_reverse(), resolved_locks, txn_result_info, kvs, has_more,
+                            request->key_only(), request->is_reverse(), resolved_locks, enable_lock_collection,
+                            txn_result_info, kvs, entries, has_more,
                             end_key, !request->has_coprocessor(), request->coprocessor());
 
   if (BAIDU_UNLIKELY(!status.ok())) {
@@ -1853,7 +1857,15 @@ void DoTxnScan(StoragePtr storage, google::protobuf::RpcController* controller,
     return;
   }
 
-  if (!kvs.empty()) {
+  CHECK(kvs.empty() || entries.empty())
+      << "kvs and entries cannot be both non-empty";
+  CHECK(entries.empty() || txn_result_info.ByteSizeLong() == 0)
+      << "txn_result_info and entries cannot be both non-empty";
+  if (!entries.empty()) {
+    for (auto &entry : entries) {
+      *response->add_entries() = std::move(entry);
+    }
+  } else if (!kvs.empty()) {
     Helper::VectorToPbRepeated(kvs, response->mutable_kvs());
   }
 

--- a/src/server/store_service.cc
+++ b/src/server/store_service.cc
@@ -1768,6 +1768,10 @@ static butil::Status ValidateTxnScanRequest(const pb::store::TxnScanRequest* req
   if (request->start_ts() < 0) {
     return butil::Status(pb::error::EILLEGAL_PARAMTETERS, "param start_ts is invalid");
   }
+  if (request->enable_lock_collection() && request->has_coprocessor()) {
+    return butil::Status(pb::error::EILLEGAL_PARAMTETERS,
+                         "lock collection does not support coprocessor");
+  }
   auto status = ServiceHelper::ValidateRegionEpoch(request->context().region_epoch(), region);
   if (!status.ok()) {
     return status;

--- a/test/unit_test/txn/test_txn_scan.cc
+++ b/test/unit_test/txn/test_txn_scan.cc
@@ -758,6 +758,7 @@ TEST_F(TxnScanTest, Scan) {
   bool key_only = false;
   size_t limit = 10;
   std::vector<pb::common::KeyValue> kvs;
+  std::vector<pb::store::TxnScanEntry> entries;
   bool is_reverse = false;
   pb::store::TxnResultInfo txn_result_info;
   std::string end_key;
@@ -770,8 +771,8 @@ TEST_F(TxnScanTest, Scan) {
 
   auto stream = Stream::New(10000000);
   ok = TxnEngineHelper::Scan(ctx, stream, engine, pb::store::IsolationLevel::SnapshotIsolation, ++end_ts, range, limit,
-                             key_only, is_reverse, resolved_locks, false, pb_coprocessor, txn_result_info, kvs,
-                             has_more, end_key);
+                             key_only, is_reverse, resolved_locks, false, pb_coprocessor, false, txn_result_info, kvs,
+                             entries, has_more, end_key);
 
   cnt = kvs.size();
 

--- a/test/unit_test/txn/test_txn_scan_lock_collection.cc
+++ b/test/unit_test/txn/test_txn_scan_lock_collection.cc
@@ -399,6 +399,31 @@ TEST_F(TxnScanLockCollectionTest, DisabledReturnsTxnResult) {
   EXPECT_EQ(output.txn_result_info.locked().lock_ts(), 50);
 }
 
+TEST_F(TxnScanLockCollectionTest, CoprocessorRejected) {
+  const std::string prefix = "txn_scan_lc_coprocessor_reject_";
+  ClearTxnPrefix(engine, prefix);
+
+  auto stream = Stream::New(1000);
+  auto ctx = std::make_shared<Context>();
+  ctx->SetTracker(Tracker::New(pb::common::RequestInfo()));
+
+  pb::common::Range range;
+  range.set_start_key(prefix);
+  range.set_end_key(Helper::PrefixNext(prefix));
+
+  ScanOutput output;
+  output.stream = stream;
+  pb::common::CoprocessorV2 coprocessor;
+  output.status = TxnEngineHelper::Scan(
+      ctx, output.stream, engine, pb::store::IsolationLevel::SnapshotIsolation, 100, range, 1000, false, false, {}, false,
+      coprocessor, true, output.txn_result_info, output.kvs, output.entries, output.has_more, output.end_key);
+
+  EXPECT_FALSE(output.status.ok());
+  EXPECT_EQ(output.status.error_code(), pb::error::Errno::EILLEGAL_PARAMTETERS);
+  EXPECT_EQ(output.entries.size(), 0);
+  EXPECT_EQ(output.kvs.size(), 0);
+}
+
 TEST_F(TxnScanLockCollectionTest, PaginationEndKeyAndContinue) {
   const std::string prefix = "txn_scan_lc_page_";
   ClearTxnPrefix(engine, prefix);
@@ -590,35 +615,6 @@ TEST_F(TxnScanLockCollectionTest, ReadCommittedIgnoresNonConflictingLocks) {
   ExpectKvEntry(output.entries[1], k2, "old_v2");
   ExpectKvEntry(output.entries[2], k3, "old_v3");
   ExpectKvEntry(output.entries[3], k4, "old_v4");
-}
-
-TEST_F(TxnScanLockCollectionTest, CoprocessorSilentDowngrade) {
-  const std::string prefix = "txn_scan_lc_coproc_down_";
-  ClearTxnPrefix(engine, prefix);
-
-  const std::string k1 = TestKey(prefix, "001");
-  PutLock(engine, k1, 50);
-
-  auto stream = Stream::New(1000);
-  auto ctx = std::make_shared<Context>();
-  ctx->SetTracker(Tracker::New(pb::common::RequestInfo()));
-
-  pb::common::Range range;
-  range.set_start_key(prefix);
-  range.set_end_key(Helper::PrefixNext(prefix));
-
-  ScanOutput output;
-  output.stream = stream;
-  pb::common::CoprocessorV2 coprocessor;
-  // enable_lock_collection=true, disable_coprocessor=false
-  output.status = TxnEngineHelper::Scan(
-      ctx, output.stream, engine, pb::store::IsolationLevel::SnapshotIsolation, 100, range, 1000, false, false, {},
-      false, coprocessor, true, output.txn_result_info, output.kvs, output.entries, output.has_more, output.end_key);
-
-  // This fixture cannot build a fully valid CoprocessorV2 cheaply: Open() depends on schemas and rel_expr decoding.
-  // Only pin the store-side contract here: coprocessor mode disables lock-collection entries.
-  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
-  EXPECT_EQ(output.entries.size(), 0) << "Lock collection should be silently disabled when coprocessor is present";
 }
 
 }  // namespace dingodb

--- a/test/unit_test/txn/test_txn_scan_lock_collection.cc
+++ b/test/unit_test/txn/test_txn_scan_lock_collection.cc
@@ -1,0 +1,624 @@
+// Copyright (c) 2023 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "butil/status.h"
+#include "common/constant.h"
+#include "common/context.h"
+#include "common/helper.h"
+#include "common/stream.h"
+#include "common/tracker.h"
+#include "config/config.h"
+#include "config/yaml_config.h"
+#include "engine/rocks_raw_engine.h"
+#include "engine/txn_engine_helper.h"
+#include "mvcc/codec.h"
+#include "proto/common.pb.h"
+#include "proto/error.pb.h"
+#include "proto/store.pb.h"
+
+namespace dingodb {
+
+namespace {
+
+const std::string kRootPath = "./unit_test_txn_scan_lock_collection";
+const std::string kLogPath = kRootPath + "/log";
+const std::string kStorePath = kRootPath + "/db";
+
+const std::string kYamlConfigContent =
+    "cluster:\n"
+    "  name: dingodb\n"
+    "  instance_id: 12345\n"
+    "  coordinators: 127.0.0.1:19190,127.0.0.1:19191,127.0.0.1:19192\n"
+    "  keyring: TO_BE_CONTINUED\n"
+    "server:\n"
+    "  host: 127.0.0.1\n"
+    "  port: 23000\n"
+    "log:\n"
+    "  path: " +
+    kLogPath +
+    "\n"
+    "store:\n"
+    "  path: " +
+    kStorePath + "\n";
+
+struct ScanOutput {
+  butil::Status status;
+  pb::store::TxnResultInfo txn_result_info;
+  std::vector<pb::common::KeyValue> kvs;
+  std::vector<pb::store::TxnScanEntry> entries;
+  bool has_more{false};
+  std::string end_key;
+  StreamPtr stream;
+};
+
+class TxnScanLockCollectionTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    Helper::CreateDirectories(kStorePath);
+
+    std::shared_ptr<Config> config = std::make_shared<YamlConfig>();
+    ASSERT_EQ(0, config->Load(kYamlConfigContent));
+
+    engine = std::make_shared<RocksRawEngine>();
+    ASSERT_TRUE(engine != nullptr);
+    ASSERT_TRUE(engine->Init(config, kAllCFs));
+  }
+
+  static void TearDownTestSuite() {
+    engine->Close();
+    engine->Destroy();
+    Helper::RemoveAllFileOrDirectory(kRootPath);
+  }
+
+  static inline std::shared_ptr<RocksRawEngine> engine;
+
+ private:
+  static const std::vector<std::string> kAllCFs;
+};
+
+const std::vector<std::string> TxnScanLockCollectionTest::kAllCFs = {
+    Constant::kTxnWriteCF,
+    Constant::kTxnDataCF,
+    Constant::kTxnLockCF,
+    "default",
+};
+
+static void ClearTxnPrefix(const std::shared_ptr<RocksRawEngine> &engine, const std::string &prefix) {
+  pb::common::Range range;
+  range.set_start_key(mvcc::Codec::EncodeKey(prefix, Constant::kMaxVer));
+  range.set_end_key(mvcc::Codec::EncodeKey(Helper::PrefixNext(prefix), 0));
+
+  auto writer = engine->Writer();
+  ASSERT_EQ(writer->KvDeleteRange(Constant::kTxnWriteCF, range).error_code(), pb::error::OK);
+  ASSERT_EQ(writer->KvDeleteRange(Constant::kTxnDataCF, range).error_code(), pb::error::OK);
+  ASSERT_EQ(writer->KvDeleteRange(Constant::kTxnLockCF, range).error_code(), pb::error::OK);
+}
+
+static std::string TestKey(const std::string &prefix, const std::string &suffix) { return prefix + suffix; }
+
+static void PutCommitted(const std::shared_ptr<RocksRawEngine> &engine, const std::string &key, const std::string &value,
+                         int64_t start_ts, int64_t commit_ts) {
+  pb::store::WriteInfo write_info;
+  write_info.set_start_ts(start_ts);
+  write_info.set_op(pb::store::Op::Put);
+
+  pb::common::KeyValue write_kv;
+  write_kv.set_key(mvcc::Codec::EncodeKey(key, commit_ts));
+  write_kv.set_value(write_info.SerializeAsString());
+  ASSERT_EQ(engine->Writer()->KvPut(Constant::kTxnWriteCF, write_kv).error_code(), pb::error::OK);
+
+  pb::common::KeyValue data_kv;
+  data_kv.set_key(mvcc::Codec::EncodeKey(key, start_ts));
+  data_kv.set_value(value);
+  ASSERT_EQ(engine->Writer()->KvPut(Constant::kTxnDataCF, data_kv).error_code(), pb::error::OK);
+}
+
+static void PutLock(const std::shared_ptr<RocksRawEngine> &engine, const std::string &key, int64_t lock_ts,
+                    int64_t min_commit_ts = 0, pb::store::Op lock_type = pb::store::Op::Put,
+                    int64_t for_update_ts = 0) {
+  pb::store::LockInfo lock_info;
+  lock_info.set_primary_lock(key);
+  lock_info.set_lock_ts(lock_ts);
+  lock_info.set_key(key);
+  lock_info.set_lock_ttl(1000);
+  lock_info.set_lock_type(lock_type);
+  lock_info.set_min_commit_ts(min_commit_ts);
+  lock_info.set_for_update_ts(for_update_ts);
+
+  pb::common::KeyValue lock_kv;
+  lock_kv.set_key(mvcc::Codec::EncodeKey(key, Constant::kLockVer));
+  lock_kv.set_value(lock_info.SerializeAsString());
+  ASSERT_EQ(engine->Writer()->KvPut(Constant::kTxnLockCF, lock_kv).error_code(), pb::error::OK);
+}
+
+static ScanOutput RunScan(const std::shared_ptr<RocksRawEngine> &engine, const std::string &prefix, int64_t scan_ts,
+                          bool enable_lock_collection, const std::set<int64_t> &resolved_locks = {},
+                          StreamPtr stream = nullptr, uint32_t stream_limit = 1000, bool key_only = false) {
+  ScanOutput output;
+  output.stream = stream == nullptr ? Stream::New(stream_limit) : stream;
+
+  auto ctx = std::make_shared<Context>();
+  pb::common::RequestInfo request_info;
+  ctx->SetTracker(Tracker::New(request_info));
+
+  pb::common::Range range;
+  range.set_start_key(prefix);
+  range.set_end_key(Helper::PrefixNext(prefix));
+
+  pb::common::CoprocessorV2 coprocessor;
+  output.status = TxnEngineHelper::Scan(ctx, output.stream, engine, pb::store::IsolationLevel::SnapshotIsolation,
+                                        scan_ts, range, stream_limit, key_only, false, resolved_locks, true, coprocessor,
+                                        enable_lock_collection, output.txn_result_info, output.kvs, output.entries,
+                                        output.has_more, output.end_key);
+  return output;
+}
+
+static void ExpectKvEntry(const pb::store::TxnScanEntry &entry, const std::string &key, const std::string &value) {
+  ASSERT_TRUE(entry.has_kv()) << entry.ShortDebugString();
+  EXPECT_EQ(entry.kv().key(), key);
+  EXPECT_EQ(entry.kv().value(), value);
+}
+
+static void ExpectKeyOnlyEntry(const pb::store::TxnScanEntry &entry, const std::string &key) {
+  ASSERT_TRUE(entry.has_kv()) << entry.ShortDebugString();
+  EXPECT_EQ(entry.kv().key(), key);
+  EXPECT_TRUE(entry.kv().value().empty());
+}
+
+static void ExpectLockedEntry(const pb::store::TxnScanEntry &entry, const std::string &key, int64_t lock_ts) {
+  ASSERT_TRUE(entry.has_locked()) << entry.ShortDebugString();
+  EXPECT_EQ(entry.locked().key(), key);
+  EXPECT_EQ(entry.locked().lock_ts(), lock_ts);
+}
+
+}  // namespace
+
+TEST_F(TxnScanLockCollectionTest, EmptyRange) {
+  const std::string prefix = "txn_scan_lc_empty_";
+  ClearTxnPrefix(engine, prefix);
+
+  auto output = RunScan(engine, prefix, 100, true);
+
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_FALSE(output.has_more);
+  EXPECT_EQ(output.kvs.size(), 0);
+  EXPECT_EQ(output.txn_result_info.ByteSizeLong(), 0);
+  EXPECT_EQ(output.entries.size(), 0);
+}
+
+TEST_F(TxnScanLockCollectionTest, NoLockReturnsEntriesInOrder) {
+  const std::string prefix = "txn_scan_lc_no_lock_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  const std::string k3 = TestKey(prefix, "003");
+  PutCommitted(engine, k1, "v1", 10, 20);
+  PutCommitted(engine, k2, "v2", 11, 21);
+  PutCommitted(engine, k3, "v3", 12, 22);
+
+  auto output = RunScan(engine, prefix, 100, true);
+
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_FALSE(output.has_more);
+  EXPECT_EQ(output.kvs.size(), 0);
+  EXPECT_EQ(output.txn_result_info.ByteSizeLong(), 0);
+  ASSERT_EQ(output.entries.size(), 3);
+  ExpectKvEntry(output.entries[0], k1, "v1");
+  ExpectKvEntry(output.entries[1], k2, "v2");
+  ExpectKvEntry(output.entries[2], k3, "v3");
+}
+
+TEST_F(TxnScanLockCollectionTest, KeyOnlyOmitsValuesButKeepsLockedEntries) {
+  const std::string prefix = "txn_scan_lc_key_only_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  const std::string k3 = TestKey(prefix, "003");
+  PutCommitted(engine, k1, "v1", 10, 20);
+  PutLock(engine, k2, 50);
+  PutCommitted(engine, k3, "v3", 12, 22);
+
+  auto output = RunScan(engine, prefix, 100, true, {}, nullptr, 1000, true);
+
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_FALSE(output.has_more);
+  EXPECT_EQ(output.kvs.size(), 0);
+  EXPECT_EQ(output.txn_result_info.ByteSizeLong(), 0);
+  ASSERT_EQ(output.entries.size(), 3);
+  ExpectKeyOnlyEntry(output.entries[0], k1);
+  ExpectLockedEntry(output.entries[1], k2, 50);
+  ExpectKeyOnlyEntry(output.entries[2], k3);
+}
+
+TEST_F(TxnScanLockCollectionTest, OnlyLocks) {
+  const std::string prefix = "txn_scan_lc_only_lock_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  const std::string k3 = TestKey(prefix, "003");
+  PutLock(engine, k1, 50);
+  PutLock(engine, k2, 51);
+  PutLock(engine, k3, 52);
+
+  auto output = RunScan(engine, prefix, 100, true);
+
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_FALSE(output.has_more);
+  EXPECT_EQ(output.kvs.size(), 0);
+  EXPECT_EQ(output.txn_result_info.ByteSizeLong(), 0);
+  ASSERT_EQ(output.entries.size(), 3);
+  ExpectLockedEntry(output.entries[0], k1, 50);
+  ExpectLockedEntry(output.entries[1], k2, 51);
+  ExpectLockedEntry(output.entries[2], k3, 52);
+}
+
+TEST_F(TxnScanLockCollectionTest, MiddleKeyLockedOrderPreserved) {
+  const std::string prefix = "txn_scan_lc_mid_lock_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  const std::string k3 = TestKey(prefix, "003");
+  const std::string k4 = TestKey(prefix, "004");
+  const std::string k5 = TestKey(prefix, "005");
+  PutCommitted(engine, k1, "v1", 10, 20);
+  PutLock(engine, k2, 50);
+  PutLock(engine, k3, 51);
+  PutLock(engine, k4, 52);
+  PutCommitted(engine, k5, "v5", 14, 24);
+
+  auto output = RunScan(engine, prefix, 100, true);
+
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_FALSE(output.has_more);
+  EXPECT_EQ(output.kvs.size(), 0);
+  EXPECT_EQ(output.txn_result_info.ByteSizeLong(), 0);
+  ASSERT_EQ(output.entries.size(), 5);
+  ExpectKvEntry(output.entries[0], k1, "v1");
+  ExpectLockedEntry(output.entries[1], k2, 50);
+  ExpectLockedEntry(output.entries[2], k3, 51);
+  ExpectLockedEntry(output.entries[3], k4, 52);
+  ExpectKvEntry(output.entries[4], k5, "v5");
+}
+
+TEST_F(TxnScanLockCollectionTest, LockedKeyAlsoHasWriteReturnsLockedOnly) {
+  const std::string prefix = "txn_scan_lc_lock_with_write_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  PutCommitted(engine, k1, "old_v1", 10, 20);
+  PutLock(engine, k1, 50);
+  PutCommitted(engine, k2, "v2", 11, 21);
+
+  auto output = RunScan(engine, prefix, 100, true);
+
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_EQ(output.kvs.size(), 0);
+  EXPECT_EQ(output.txn_result_info.ByteSizeLong(), 0);
+  ASSERT_EQ(output.entries.size(), 2);
+  ExpectLockedEntry(output.entries[0], k1, 50);
+  ExpectKvEntry(output.entries[1], k2, "v2");
+}
+
+TEST_F(TxnScanLockCollectionTest, LockPlusWriteWriteIterExhausted) {
+  const std::string prefix = "txn_scan_lc_lock_with_write_end_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  PutCommitted(engine, k1, "old_v1", 10, 20);
+  PutLock(engine, k1, 50);
+
+  auto output = RunScan(engine, prefix, 100, true);
+
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_FALSE(output.has_more);
+  EXPECT_EQ(output.kvs.size(), 0);
+  EXPECT_EQ(output.txn_result_info.ByteSizeLong(), 0);
+  ASSERT_EQ(output.entries.size(), 1);
+  ExpectLockedEntry(output.entries[0], k1, 50);
+}
+
+TEST_F(TxnScanLockCollectionTest, ResolvedLockIgnoredReturnsVisibleValue) {
+  const std::string prefix = "txn_scan_lc_resolved_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  PutCommitted(engine, k1, "old_v1", 10, 20);
+  PutLock(engine, k1, 50);
+  PutCommitted(engine, k2, "v2", 11, 21);
+
+  auto output = RunScan(engine, prefix, 100, true, {50});
+
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_EQ(output.txn_result_info.ByteSizeLong(), 0);
+  ASSERT_EQ(output.entries.size(), 2);
+  ExpectKvEntry(output.entries[0], k1, "old_v1");
+  ExpectKvEntry(output.entries[1], k2, "v2");
+}
+
+TEST_F(TxnScanLockCollectionTest, MinCommitTsGreaterThanStartTsIgnored) {
+  const std::string prefix = "txn_scan_lc_min_commit_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  PutCommitted(engine, k1, "old_v1", 10, 20);
+  PutLock(engine, k1, 50, 101);
+  PutCommitted(engine, k2, "v2", 11, 21);
+
+  auto output = RunScan(engine, prefix, 100, true);
+
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_EQ(output.txn_result_info.ByteSizeLong(), 0);
+  ASSERT_EQ(output.entries.size(), 2);
+  ExpectKvEntry(output.entries[0], k1, "old_v1");
+  ExpectKvEntry(output.entries[1], k2, "v2");
+}
+
+TEST_F(TxnScanLockCollectionTest, DisabledReturnsTxnResult) {
+  const std::string prefix = "txn_scan_lc_disabled_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  PutLock(engine, k1, 50);
+  PutCommitted(engine, k2, "v2", 11, 21);
+
+  auto output = RunScan(engine, prefix, 100, false);
+
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_TRUE(output.has_more);
+  EXPECT_EQ(output.entries.size(), 0);
+  EXPECT_EQ(output.kvs.size(), 0);
+  ASSERT_TRUE(output.txn_result_info.has_locked()) << output.txn_result_info.ShortDebugString();
+  EXPECT_EQ(output.txn_result_info.locked().key(), k1);
+  EXPECT_EQ(output.txn_result_info.locked().lock_ts(), 50);
+}
+
+TEST_F(TxnScanLockCollectionTest, PaginationEndKeyAndContinue) {
+  const std::string prefix = "txn_scan_lc_page_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  const std::string k3 = TestKey(prefix, "003");
+  PutLock(engine, k1, 50);
+  PutCommitted(engine, k2, "v2", 11, 21);
+  PutCommitted(engine, k3, "v3", 12, 22);
+
+  auto first = RunScan(engine, prefix, 100, true, {}, nullptr, 2);
+
+  ASSERT_TRUE(first.status.ok()) << first.status.error_str();
+  EXPECT_TRUE(first.has_more);
+  EXPECT_EQ(first.end_key, k2);
+  ASSERT_EQ(first.entries.size(), 2);
+  ExpectLockedEntry(first.entries[0], k1, 50);
+  ExpectKvEntry(first.entries[1], k2, "v2");
+
+  auto second = RunScan(engine, prefix, 100, true, {}, first.stream, 2);
+
+  ASSERT_TRUE(second.status.ok()) << second.status.error_str();
+  EXPECT_FALSE(second.has_more);
+  ASSERT_EQ(second.entries.size(), 1);
+  ExpectKvEntry(second.entries[0], k3, "v3");
+}
+
+TEST_F(TxnScanLockCollectionTest, PaginationEndKeyCanBeLockedEntry) {
+  const std::string prefix = "txn_scan_lc_page_locked_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  const std::string k3 = TestKey(prefix, "003");
+  PutCommitted(engine, k1, "v1", 10, 20);
+  PutLock(engine, k2, 50);
+  PutCommitted(engine, k3, "v3", 12, 22);
+
+  auto first = RunScan(engine, prefix, 100, true, {}, nullptr, 2);
+
+  ASSERT_TRUE(first.status.ok()) << first.status.error_str();
+  EXPECT_TRUE(first.has_more);
+  EXPECT_EQ(first.end_key, k2);
+  ASSERT_EQ(first.entries.size(), 2);
+  ExpectKvEntry(first.entries[0], k1, "v1");
+  ExpectLockedEntry(first.entries[1], k2, 50);
+
+  auto second = RunScan(engine, prefix, 100, true, {}, first.stream, 2);
+
+  ASSERT_TRUE(second.status.ok()) << second.status.error_str();
+  EXPECT_FALSE(second.has_more);
+  ASSERT_EQ(second.entries.size(), 1);
+  ExpectKvEntry(second.entries[0], k3, "v3");
+}
+
+TEST_F(TxnScanLockCollectionTest, StreamRejectsModeChange) {
+  const std::string prefix = "txn_scan_lc_mode_change_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  PutLock(engine, k1, 50);
+  PutCommitted(engine, k2, "v2", 11, 21);
+
+  auto first = RunScan(engine, prefix, 100, true, {}, nullptr, 1);
+
+  ASSERT_TRUE(first.status.ok()) << first.status.error_str();
+  EXPECT_TRUE(first.has_more);
+  ASSERT_EQ(first.entries.size(), 1);
+  ExpectLockedEntry(first.entries[0], k1, 50);
+
+  auto second = RunScan(engine, prefix, 100, false, {}, first.stream, 1);
+
+  EXPECT_FALSE(second.status.ok());
+  EXPECT_EQ(second.status.error_code(), pb::error::Errno::EILLEGAL_PARAMTETERS);
+}
+
+TEST_F(TxnScanLockCollectionTest, StreamDoesNotRefreshResolvedLocks) {
+  const std::string prefix = "txn_scan_lc_no_refresh_resolved_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  const std::string k3 = TestKey(prefix, "003");
+  PutCommitted(engine, k1, "v1", 10, 20);
+  PutCommitted(engine, k2, "old_v2", 11, 21);
+  PutLock(engine, k2, 50);
+  PutCommitted(engine, k3, "v3", 12, 22);
+
+  auto first = RunScan(engine, prefix, 100, true, {}, nullptr, 1);
+
+  ASSERT_TRUE(first.status.ok()) << first.status.error_str();
+  EXPECT_TRUE(first.has_more);
+  ASSERT_EQ(first.entries.size(), 1);
+  ExpectKvEntry(first.entries[0], k1, "v1");
+
+  auto second = RunScan(engine, prefix, 100, true, {50}, first.stream, 1);
+
+  ASSERT_TRUE(second.status.ok()) << second.status.error_str();
+  EXPECT_TRUE(second.has_more);
+  ASSERT_EQ(second.entries.size(), 1);
+  ExpectLockedEntry(second.entries[0], k2, 50);
+}
+
+TEST_F(TxnScanLockCollectionTest, ReadCommitted) {
+  const std::string prefix = "txn_scan_lc_rc_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  PutCommitted(engine, k1, "v1", 10, 20);
+
+  // In RC mode, only pessimistic prewrite locks (for_update_ts > 0, lock_type != Lock)
+  // trigger conflicts. Set up a pessimistic prewrite lock with for_update_ts < start_ts.
+  {
+    pb::store::LockInfo lock_info;
+    lock_info.set_primary_lock(k2);
+    lock_info.set_lock_ts(50);
+    lock_info.set_key(k2);
+    lock_info.set_lock_ttl(1000);
+    lock_info.set_lock_type(pb::store::Op::Put);
+    lock_info.set_for_update_ts(30);
+
+    pb::common::KeyValue lock_kv;
+    lock_kv.set_key(mvcc::Codec::EncodeKey(k2, Constant::kLockVer));
+    lock_kv.set_value(lock_info.SerializeAsString());
+    ASSERT_EQ(engine->Writer()->KvPut(Constant::kTxnLockCF, lock_kv).error_code(), pb::error::OK);
+  }
+
+  auto stream = Stream::New(1000);
+  auto ctx = std::make_shared<Context>();
+  ctx->SetTracker(Tracker::New(pb::common::RequestInfo()));
+
+  pb::common::Range range;
+  range.set_start_key(prefix);
+  range.set_end_key(Helper::PrefixNext(prefix));
+
+  ScanOutput output;
+  output.stream = stream;
+  pb::common::CoprocessorV2 coprocessor;
+  output.status = TxnEngineHelper::Scan(
+      ctx, output.stream, engine, pb::store::IsolationLevel::ReadCommitted, 100, range, 1000, false, false, {}, true,
+      coprocessor, true, output.txn_result_info, output.kvs, output.entries, output.has_more, output.end_key);
+
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_FALSE(output.has_more);
+  ASSERT_EQ(output.entries.size(), 2);
+  ExpectKvEntry(output.entries[0], k1, "v1");
+  ExpectLockedEntry(output.entries[1], k2, 50);
+}
+
+TEST_F(TxnScanLockCollectionTest, ReadCommittedIgnoresNonConflictingLocks) {
+  const std::string prefix = "txn_scan_lc_rc_ignore_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  const std::string k2 = TestKey(prefix, "002");
+  const std::string k3 = TestKey(prefix, "003");
+  const std::string k4 = TestKey(prefix, "004");
+  PutCommitted(engine, k1, "v1", 10, 20);
+  PutCommitted(engine, k2, "old_v2", 11, 21);
+  PutCommitted(engine, k3, "old_v3", 12, 22);
+  PutCommitted(engine, k4, "old_v4", 13, 23);
+  PutLock(engine, k2, 50, 0, pb::store::Op::Lock, 30);
+  PutLock(engine, k3, 51, 0, pb::store::Op::Put, 100);
+  PutLock(engine, k4, 52);
+
+  auto stream = Stream::New(1000);
+  auto ctx = std::make_shared<Context>();
+  ctx->SetTracker(Tracker::New(pb::common::RequestInfo()));
+
+  pb::common::Range range;
+  range.set_start_key(prefix);
+  range.set_end_key(Helper::PrefixNext(prefix));
+
+  ScanOutput output;
+  output.stream = stream;
+  pb::common::CoprocessorV2 coprocessor;
+  output.status = TxnEngineHelper::Scan(
+      ctx, output.stream, engine, pb::store::IsolationLevel::ReadCommitted, 100, range, 1000, false, false, {}, true,
+      coprocessor, true, output.txn_result_info, output.kvs, output.entries, output.has_more, output.end_key);
+
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_FALSE(output.has_more);
+  EXPECT_EQ(output.txn_result_info.ByteSizeLong(), 0);
+  ASSERT_EQ(output.entries.size(), 4);
+  ExpectKvEntry(output.entries[0], k1, "v1");
+  ExpectKvEntry(output.entries[1], k2, "old_v2");
+  ExpectKvEntry(output.entries[2], k3, "old_v3");
+  ExpectKvEntry(output.entries[3], k4, "old_v4");
+}
+
+TEST_F(TxnScanLockCollectionTest, CoprocessorSilentDowngrade) {
+  const std::string prefix = "txn_scan_lc_coproc_down_";
+  ClearTxnPrefix(engine, prefix);
+
+  const std::string k1 = TestKey(prefix, "001");
+  PutLock(engine, k1, 50);
+
+  auto stream = Stream::New(1000);
+  auto ctx = std::make_shared<Context>();
+  ctx->SetTracker(Tracker::New(pb::common::RequestInfo()));
+
+  pb::common::Range range;
+  range.set_start_key(prefix);
+  range.set_end_key(Helper::PrefixNext(prefix));
+
+  ScanOutput output;
+  output.stream = stream;
+  pb::common::CoprocessorV2 coprocessor;
+  // enable_lock_collection=true, disable_coprocessor=false
+  output.status = TxnEngineHelper::Scan(
+      ctx, output.stream, engine, pb::store::IsolationLevel::SnapshotIsolation, 100, range, 1000, false, false, {},
+      false, coprocessor, true, output.txn_result_info, output.kvs, output.entries, output.has_more, output.end_key);
+
+  // This fixture cannot build a fully valid CoprocessorV2 cheaply: Open() depends on schemas and rel_expr decoding.
+  // Only pin the store-side contract here: coprocessor mode disables lock-collection entries.
+  ASSERT_TRUE(output.status.ok()) << output.status.error_str();
+  EXPECT_EQ(output.entries.size(), 0) << "Lock collection should be silently disabled when coprocessor is present";
+}
+
+}  // namespace dingodb


### PR DESCRIPTION
1. Add enable_lock_collection flag through the entire TxnScan call chain. In lock collection mode, record locks as TxnScanEntry entries instead of aborting on lock conflict; silently disabled when coprocessor is active.
2. Update service layer to route output (entries vs kvs) and add comprehensive unit tests for lock collection mode.