### PR TITLE
 [fix][coordinator] Resolved: If a shadows region appears, it can now be removed using DropRegionPermanently.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,9 @@ docker/rocky8/rust-1.78.0-x86_64-unknown-linux-gnu.tar.xz
 # claude
 CLAUDE.md
 
+# Claude Code working directory
+/docs/
+/.claude/
 
 #codex
 .codex

--- a/conf/coordinator.template.yaml
+++ b/conf/coordinator.template.yaml
@@ -43,5 +43,3 @@ store:
   background_thread_num: 16 # background_thread_num priority background_thread_ratio
   # background_thread_ratio: 0.5 # cpu core * ratio
   stats_dump_period_s: 120
-region:
-  split_strategy: POST_CREATE_REGION

--- a/src/client/coordinator_client_function_coor.cc
+++ b/src/client/coordinator_client_function_coor.cc
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <unistd.h>
+
 #include <cstdint>
+#include <cstdlib>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -100,6 +104,19 @@ DECLARE_int64(tenant_id);
 DECLARE_bool(get_all_tenant);
 
 DEFINE_bool(get_coordinator_map, false, "get_coordinator_map");
+DEFINE_bool(enable_store_verify, true,
+            "If true (default), DropRegionPermanently performs VerifyPeersOnStore "
+            "to confirm the region is absent from all stores before deletion. "
+            "Set to false to skip verification (DANGEROUS). "
+            "Note: verify=true rejects a region whose store-side deletion is "
+            "still in flight (the store still has region meta even though state "
+            "is DELETED); retry once store-side cleanup completes.");
+DEFINE_bool(confirm_dangerous, false,
+            "Acknowledge that --enable_store_verify=false is a DANGEROUS operation "
+            "(may orphan store data) and skip the interactive confirmation prompt that "
+            "DropRegionPermanently otherwise shows. Use this in non-TTY callers (CI, "
+            "scripts) that cannot answer the prompt. "
+            "No-op unless --enable_store_verify=false.");
 
 DEFINE_bool(use_filter_store_type, false, "use filter_store_type");
 DEFINE_int32(filter_store_type, 0, "filter_store_type");
@@ -1449,9 +1466,50 @@ void SendDropRegionPermanently(std::shared_ptr<dingodb::CoordinatorInteraction> 
     return;
   }
 
+  request.set_enable_store_verify(FLAGS_enable_store_verify);
+
+  // When the safety check is disabled we require operator acknowledgement.
+  // Two paths:
+  //   1. --confirm_dangerous was passed: caller has acknowledged on the command line.
+  //   2. TTY available: prompt interactively for an explicit confirmation.
+  //   3. Otherwise (piped stdin / CI / no TTY): refuse with a non-zero exit code.
+  //      A silent abort here would let SRE automation believe the drop succeeded.
+  if (!FLAGS_enable_store_verify && !FLAGS_confirm_dangerous) {
+    if (!isatty(fileno(stdin))) {
+      DINGO_LOG(ERROR) << "--enable_store_verify=false requires either an interactive TTY "
+                          "or --confirm_dangerous to acknowledge the risk. "
+                          "Refusing to proceed in non-interactive mode.";
+      std::cerr << "ERROR: --enable_store_verify=false requires either an interactive TTY "
+                   "or --confirm_dangerous to acknowledge the risk. "
+                   "Refusing to proceed in non-interactive mode."
+                << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
+    std::cout << "============================================================\n"
+              << "  WARNING: --enable_store_verify=false\n"
+              << "============================================================\n"
+              << "This will PERMANENTLY erase coordinator metadata for region " << FLAGS_id << "\n"
+              << "WITHOUT confirming the region is absent from all stores.\n\n"
+              << "Misuse can cause data to become inaccessible (coordinator no longer\n"
+              << "schedules the region while store data remains orphaned).\n\n"
+              << "Type 'YES' or 'Yes' or 'yes' or 'Y' or 'y' to confirm, anything else to abort:\n"
+              << "> " << std::flush;
+    std::string confirmation_raw;
+    std::getline(std::cin, confirmation_raw);
+    // Trim leading/trailing whitespace so 'yes  ' or '  Y\r' still parse.
+    std::string confirmation = dingodb::Helper::Trim(confirmation_raw, " \t\r\n");
+    if (confirmation != "YES" && confirmation != "Yes" && confirmation != "yes" && confirmation != "Y" &&
+        confirmation != "y") {
+      DINGO_LOG(WARNING) << "DropRegionPermanently aborted by user (entered: '" << confirmation_raw << "')";
+      std::cerr << "DropRegionPermanently aborted by user (entered: '" << confirmation_raw << "')" << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
+  }
+
   auto status = coordinator_interaction->SendRequest("DropRegionPermanently", request, response);
   DINGO_LOG(INFO) << "SendRequest status=" << status;
-  DINGO_LOG(INFO) << response.DebugString();
+  DINGO_LOG(INFO) << "request: " << request.DebugString();
+  DINGO_LOG(INFO) << "response: " << response.DebugString();
 }
 
 void SendSplitRegion(std::shared_ptr<dingodb::CoordinatorInteraction> coordinator_interaction) {

--- a/src/client_v2/coordinator.cc
+++ b/src/client_v2/coordinator.cc
@@ -15,7 +15,10 @@
 
 #include "client_v2/coordinator.h"
 
+#include <unistd.h>
+
 #include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <map>
 #include <ostream>
@@ -47,6 +50,9 @@ void SetUpCoordinatorSubCommands(CLI::App &app) {
   SetUpMergeRegion(app);
   SetUpQueryRegion(app);
   SetUpTransferLeaderRegion(app);
+  SetUpDropRegion(app);
+  SetUpDropRegionPermanently(app);
+
   // executor
   SetUpCreateExecutor(app);
   SetUpDeleteExecutor(app);
@@ -1663,9 +1669,28 @@ void RunDropRegion(DropRegionOption const &opt) {
 
 void SetUpDropRegionPermanently(CLI::App &app) {
   auto opt = std::make_shared<DropRegionPermanentlyOption>();
-  auto *cmd = app.add_subcommand("DropRegionPermanently", "Drop region permanently")->group("Coordinator Command");
+  auto *cmd = app.add_subcommand("DropRegionPermanently",
+                                  "Drop region permanently. "
+                                  "On success the request and response are printed to stdout; "
+                                  "SendRequest status is also written to the log.")
+                     ->group("Coordinator Command");
   cmd->add_option("--coor_url", opt->coor_url, "Coordinator url, default:file://./coor_list");
   cmd->add_option("--id", opt->id, "Request parameter region id ")->required();
+  cmd->add_option("--enable_store_verify", opt->enable_store_verify,
+                  "If true (default), verify region is absent from all stores before deletion. "
+                  "Set to false to skip verification (DANGEROUS). "
+                  "Note: verify=true rejects a region whose store-side deletion is still in "
+                  "flight (the store still has region meta even though state is DELETED); "
+                  "retry once store-side cleanup completes.")
+      ->default_val(true)
+      ->default_str("true");
+  cmd->add_flag("--confirm_dangerous", opt->confirm_dangerous,
+                "Acknowledge that --enable_store_verify=false is a DANGEROUS operation "
+                "(may orphan store data) and skip the interactive confirmation prompt. "
+                "Use this in non-TTY callers (CI, scripts) that cannot answer the prompt. "
+                "No-op unless --enable_store_verify=false.")
+      ->default_val(false)
+      ->default_str("false");
   cmd->callback([opt]() { RunDropRegionPermanently(*opt); });
 }
 
@@ -1679,10 +1704,50 @@ void RunDropRegionPermanently(DropRegionPermanentlyOption const &opt) {
   dingodb::pb::coordinator::DropRegionPermanentlyResponse response;
 
   request.set_region_id(std::stoll(opt.id));
+  request.set_enable_store_verify(opt.enable_store_verify);
+
+  // When the safety check is disabled we require operator acknowledgement.
+  // Two paths:
+  //   1. --confirm_dangerous was passed: caller has acknowledged on the command line.
+  //   2. TTY available: prompt interactively for an explicit confirmation.
+  //   3. Otherwise (piped stdin / CI / no TTY): refuse with a non-zero exit code.
+  //      A silent abort here would let SRE automation believe the drop succeeded.
+  if (!opt.enable_store_verify && !opt.confirm_dangerous) {
+    if (!isatty(fileno(stdin))) {
+      std::cerr << "ERROR: --enable_store_verify=false requires either an interactive TTY "
+                   "or --confirm_dangerous to acknowledge the risk. "
+                   "Refusing to proceed in non-interactive mode."
+                << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
+    std::cout << "============================================================\n"
+              << "  WARNING: --enable_store_verify=false\n"
+              << "============================================================\n"
+              << "This will PERMANENTLY erase coordinator metadata for region " << opt.id << "\n"
+              << "WITHOUT confirming the region is absent from all stores.\n\n"
+              << "Misuse can cause data to become inaccessible (coordinator no longer\n"
+              << "schedules the region while store data remains orphaned).\n\n"
+              << "Type 'YES' or 'Yes' or 'yes' or 'Y' or 'y' to confirm, anything else to abort:\n"
+              << "> " << std::flush;
+    std::string confirmation_raw;
+    std::getline(std::cin, confirmation_raw);
+    // Trim leading/trailing whitespace so 'yes  ' or '  Y\r' still parse.
+    std::string confirmation = dingodb::Helper::Trim(confirmation_raw, " \t\r\n");
+    if (confirmation != "YES" && confirmation != "Yes" && confirmation != "yes" && confirmation != "Y" &&
+        confirmation != "y") {
+      std::cerr << "DropRegionPermanently aborted by user (entered: '" << confirmation_raw << "')" << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
+  }
+
   auto status = CoordinatorInteraction::GetInstance().GetCoorinatorInteraction()->SendRequest("DropRegionPermanently",
                                                                                               request, response);
+  // v2 is a human-facing CLI tool: write user-relevant output to stdout
+  // (operators read it directly). Only RPC-level status goes through
+  // DINGO_LOG for log aggregation; avoid double-printing request/response.
   DINGO_LOG(INFO) << "SendRequest status=" << status;
-  DINGO_LOG(INFO) << response.DebugString();
+  std::cout << "request: " << request.DebugString() << std::endl;
+  std::cout << "response: " << response.DebugString() << std::endl;
 }
 
 void SetUpSplitRegion(CLI::App &app) {

--- a/src/client_v2/coordinator.h
+++ b/src/client_v2/coordinator.h
@@ -329,6 +329,11 @@ void RunDropRegion(DropRegionOption const &opt);
 struct DropRegionPermanentlyOption {
   std::string coor_url;
   std::string id;
+  // Member initializers guarantee defined values even if CLI11 parsing is
+  // bypassed (e.g. by future SDK wrappers or unit tests). CLI11 still owns
+  // the user-visible default via ->default_val() in SetUpDropRegionPermanently.
+  bool enable_store_verify{true};
+  bool confirm_dangerous{false};
 };
 void SetUpDropRegionPermanently(CLI::App &app);
 void RunDropRegionPermanently(DropRegionPermanentlyOption const &opt);

--- a/src/coordinator/coordinator_control_coor.cc
+++ b/src/coordinator/coordinator_control_coor.cc
@@ -114,9 +114,8 @@ namespace {
   if (replica_status == pb::common::REPLICA_NORMAL) {
     return butil::Status::OK();
   }
-  std::string error_msg =
-      fmt::format("SplitRegion refuse split: {}:{} replica_status({}) is not REPLICA_NORMAL", region_role_label,
-                  region_id, pb::common::ReplicaStatus_Name(replica_status));
+  std::string error_msg = fmt::format("SplitRegion refuse split: {}:{} replica_status({}) is not REPLICA_NORMAL",
+                                      region_role_label, region_id, pb::common::ReplicaStatus_Name(replica_status));
   return butil::Status(pb::error::Errno::ESPLIT_STATUS_ILLEGAL, error_msg);
 }
 
@@ -2575,10 +2574,24 @@ butil::Status CoordinatorControl::DropRegionPermanently(int64_t region_id,
       return butil::Status(pb::error::Errno::EREGION_NOT_FOUND, "DropRegionPermanently region not exists");
     }
 
-    // if region is dropped, do real delete
-    if (region_to_delete.state() != ::dingodb::pb::common::RegionState::REGION_DELETE ||
-        region_to_delete.state() != ::dingodb::pb::common::RegionState::REGION_DELETE ||
-        region_to_delete.state() != ::dingodb::pb::common::RegionState::REGION_DELETING) {
+    // State-based gating:
+    //   * REGION_DELETE / REGION_DELETING: a deletion is already in flight
+    //     (DropRegion was called earlier, or the apply chain is mid-flight).
+    //     Re-emitting a DELETE op_type would bloat the raft log; the in-flight
+    //     path will erase the entry on its own. Skip silently.
+    //   * REGION_DELETED in region_map_: heartbeat-driven shadow case -- a store
+    //     reported store_region_state=DELETED, the heartbeat path updated the
+    //     state field via UPDATE op_type, but the region_map_ entry persists
+    //     because no module periodically scans region_map_ for REGION_DELETED
+    //     entries. DropRegionPermanently is the operator-facing tool for
+    //     cleaning these up, so we MUST emit DELETE here. FSM apply of DELETE
+    //     is idempotent (it skips when the entry is no longer in region_map_),
+    //     so emitting is safe even if a race resolved the entry between Get()
+    //     and apply().
+    //   * Any other state (NORMAL, NEW, ...): normal cleanup path.
+    const auto current_state = region_to_delete.state();
+    if (current_state != ::dingodb::pb::common::RegionState::REGION_DELETE &&
+        current_state != ::dingodb::pb::common::RegionState::REGION_DELETING) {
       region_to_delete.set_state(::dingodb::pb::common::RegionState::REGION_DELETE);
 
       // update meta_increment
@@ -2594,7 +2607,15 @@ butil::Status CoordinatorControl::DropRegionPermanently(int64_t region_id,
 
       // on_apply
       // region_map_[region_id].set_state(::dingodb::pb::common::RegionState::REGION_DELETE);
-      DINGO_LOG(INFO) << "DropRegionPermanently drop region success, id = " << region_id;
+      DINGO_LOG(INFO) << "DropRegionPermanently drop region success, id = " << region_id
+                      << " prev_state=" << pb::common::RegionState_Name(current_state);
+    } else {
+      std::string skip_msg = fmt::format(
+          "DropRegionPermanently skipped: region:{} is already in state:{} "
+          "(deletion in flight via another path)",
+          region_id, pb::common::RegionState_Name(current_state));
+      DINGO_LOG(INFO) << skip_msg;
+      return butil::Status(pb::error::Errno::EREGION_DELETING, skip_msg);
     }
   }
 
@@ -2638,8 +2659,14 @@ butil::Status CoordinatorControl::SplitRegion(int64_t split_from_region_id, int6
   }
 
   // Validate split_from_region replica_status; refuse split if not REPLICA_NORMAL.
-  butil::Status parent_replica_check = CheckReplicaStatusForSplit("split_from_region", split_from_region_id,
-                                                                  region_status.replica_status());
+  // NOTE: region_status.replica_status() is meaningful here only because the prior
+  // RAFT_HEALTHY + REGION_ONLINE check above guarantees region_status is fresh.
+  // If metrics is missing, GetRegionStatus returns a default-constructed RegionStatus
+  // (replica_status == REPLICA_NONE), but the upstream check would have already
+  // returned ESPLIT_STATUS_ILLEGAL. If those upstream checks are ever loosened,
+  // add an explicit `metrics_ret > 0` gate here, mirroring the child path below.
+  butil::Status parent_replica_check =
+      CheckReplicaStatusForSplit("split_from_region", split_from_region_id, region_status.replica_status());
   if (!parent_replica_check.ok()) {
     DINGO_LOG(ERROR) << parent_replica_check.error_str();
     return parent_replica_check;
@@ -2717,11 +2744,18 @@ butil::Status CoordinatorControl::SplitRegion(int64_t split_from_region_id, int6
   // Validate split_to_region replica_status; skip when the child has no metrics entry
   // yet (DingoSafeMap::Get returns -1, never 0). A freshly-created child without store
   // heartbeat is not considered "degraded".
+  //
+  // NOTE on STANDBY semantics: by the upstream state gate (line above) split_to_region
+  // is REGION_STANDBY at this point. STANDBY children for which no store has ever
+  // reported a heartbeat will have metrics_ret == -1 and skip the check. STANDBY
+  // children whose stores *did* send a heartbeat (e.g. a long-lived STANDBY that
+  // briefly went unhealthy) will have metrics_ret > 0 and a real replica_status --
+  // treated identically to any other state's replica_status check.
   pb::common::RegionMetrics split_to_metrics;
   int metrics_ret = region_metrics_map_.Get(split_to_region_id, split_to_metrics);
   if (metrics_ret > 0) {
-    butil::Status child_replica_check = CheckReplicaStatusForSplit(
-        "split_to_region", split_to_region_id, split_to_metrics.region_status().replica_status());
+    butil::Status child_replica_check = CheckReplicaStatusForSplit("split_to_region", split_to_region_id,
+                                                                   split_to_metrics.region_status().replica_status());
     if (!child_replica_check.ok()) {
       DINGO_LOG(ERROR) << child_replica_check.error_str();
       return child_replica_check;
@@ -2825,8 +2859,18 @@ butil::Status CoordinatorControl::SplitRegionWithJob(int64_t split_from_region_i
   }
 
   // Validate split_from_region replica_status; refuse split if not REPLICA_NORMAL.
-  butil::Status parent_replica_check = CheckReplicaStatusForSplit(
-      "split_from_region", split_from_region_id, region_metrics.region_status().replica_status());
+  // NOTE: Only the parent guard applies here. SplitRegionWithJob creates the child
+  // region in-place below via CreateRegionForSplitInternal -- no metrics exist for
+  // the child at this point, so a child replica_status check is not applicable.
+  // The child guard lives in SplitRegion() above, which is the path used when an
+  // existing region is supplied as the split target.
+  //
+  // region_metrics.region_status() is meaningful here only because the prior
+  // RAFT_HEALTHY + REGION_ONLINE check above guarantees the metrics is fresh.
+  // If those upstream checks are ever loosened, add an explicit metrics-presence
+  // gate here.
+  butil::Status parent_replica_check = CheckReplicaStatusForSplit("split_from_region", split_from_region_id,
+                                                                  region_metrics.region_status().replica_status());
   if (!parent_replica_check.ok()) {
     DINGO_LOG(ERROR) << parent_replica_check.error_str();
     return parent_replica_check;

--- a/src/coordinator/coordinator_control_coor.cc
+++ b/src/coordinator/coordinator_control_coor.cc
@@ -93,6 +93,35 @@ BRPC_VALIDATE_GFLAG(print_recycle_orphan_region_not_table_or_index, brpc::PassVa
 DEFINE_bool(print_process_job_error, true, "print process job error. default true");
 BRPC_VALIDATE_GFLAG(print_process_job_error, brpc::PassValidate);
 
+namespace {
+
+// Common pre-check used by SplitRegion / SplitRegionWithJob: refuses split when the given
+// region's replica_status is not REPLICA_NORMAL (covers DEGRAED / UNAVAILABLE / NONE).
+// NOTE: "DEGRAED" is an upstream proto enum typo (should be DEGRADED); preserved here for
+// ABI compat. To be fixed in a separate cross-module PR.
+//
+// `region_role_label` should be "split_from_region" or "split_to_region" so the returned
+// error message tells operators which side failed.
+//
+// NOTE: this helper does NOT emit a log line itself. The returned Status carries the full
+// error_str; callers are expected to DINGO_LOG(ERROR) << <status>.error_str() on failure.
+// This avoids double-logging the same content from both helper and caller.
+//
+// [[nodiscard]] is applied so the compiler warns if a future caller forgets to inspect
+// the return value -- a silent rejection without log/return would defeat the entire guard.
+[[nodiscard]] butil::Status CheckReplicaStatusForSplit(const char* region_role_label, int64_t region_id,
+                                                       pb::common::ReplicaStatus replica_status) {
+  if (replica_status == pb::common::REPLICA_NORMAL) {
+    return butil::Status::OK();
+  }
+  std::string error_msg =
+      fmt::format("SplitRegion refuse split: {}:{} replica_status({}) is not REPLICA_NORMAL", region_role_label,
+                  region_id, pb::common::ReplicaStatus_Name(replica_status));
+  return butil::Status(pb::error::Errno::ESPLIT_STATUS_ILLEGAL, error_msg);
+}
+
+}  // namespace
+
 // TODO: add epoch logic
 void CoordinatorControl::GetCoordinatorMap(int64_t cluster_id, int64_t& epoch, pb::common::Location& leader_location,
                                            std::vector<pb::common::Location>& locations,
@@ -2608,6 +2637,14 @@ butil::Status CoordinatorControl::SplitRegion(int64_t split_from_region_id, int6
                          "SplitRegion split_from_region is not ready for split");
   }
 
+  // Validate split_from_region replica_status; refuse split if not REPLICA_NORMAL.
+  butil::Status parent_replica_check = CheckReplicaStatusForSplit("split_from_region", split_from_region_id,
+                                                                  region_status.replica_status());
+  if (!parent_replica_check.ok()) {
+    DINGO_LOG(ERROR) << parent_replica_check.error_str();
+    return parent_replica_check;
+  }
+
   // check if all peers are healthy
   auto peer_status = CheckRegionAllPeerOnline(split_from_region_id);
   if (!peer_status.ok()) {
@@ -2675,6 +2712,20 @@ butil::Status CoordinatorControl::SplitRegion(int64_t split_from_region_id, int6
     return butil::Status(pb::error::Errno::ESPLIT_STATUS_ILLEGAL,
                          "SplitRegion split_from_region or "
                          "split_to_region is not ready for split");
+  }
+
+  // Validate split_to_region replica_status; skip when the child has no metrics entry
+  // yet (DingoSafeMap::Get returns -1, never 0). A freshly-created child without store
+  // heartbeat is not considered "degraded".
+  pb::common::RegionMetrics split_to_metrics;
+  int metrics_ret = region_metrics_map_.Get(split_to_region_id, split_to_metrics);
+  if (metrics_ret > 0) {
+    butil::Status child_replica_check = CheckReplicaStatusForSplit(
+        "split_to_region", split_to_region_id, split_to_metrics.region_status().replica_status());
+    if (!child_replica_check.ok()) {
+      DINGO_LOG(ERROR) << child_replica_check.error_str();
+      return child_replica_check;
+    }
   }
 
   // generate store operation for stores
@@ -2771,6 +2822,14 @@ butil::Status CoordinatorControl::SplitRegionWithJob(int64_t split_from_region_i
     DINGO_LOG(ERROR) << fmt::format("split_from_region:{} is not ready for split, from_state:{}", split_from_region_id,
                                     pb::common::RegionState_Name(split_from_region.state()));
     return butil::Status(pb::error::Errno::ESPLIT_STATUS_ILLEGAL, "SplitRegion split_from_region is not ready");
+  }
+
+  // Validate split_from_region replica_status; refuse split if not REPLICA_NORMAL.
+  butil::Status parent_replica_check = CheckReplicaStatusForSplit(
+      "split_from_region", split_from_region_id, region_metrics.region_status().replica_status());
+  if (!parent_replica_check.ok()) {
+    DINGO_LOG(ERROR) << parent_replica_check.error_str();
+    return parent_replica_check;
   }
 
   // check if all peers are healthy

--- a/src/server/coordinator_service.cc
+++ b/src/server/coordinator_service.cc
@@ -1461,6 +1461,79 @@ void DoDropRegion(google::protobuf::RpcController * /*controller*/, const pb::co
   }
 }
 
+namespace {
+
+// Validate that a region is an orphan (absent from all peer stores) before
+// DropRegionPermanently strips its coordinator metadata. Used only when
+// DropRegionPermanentlyRequest.enable_store_verify is true.
+//
+// Returns OK                    if all peers confirm absence (region is truly orphan).
+// Returns EREGION_NOT_FOUND     if the region is not in region_map_.
+// Returns EREGION_NOT_ORPHAN    if at least one peer still has the region, OR
+//                               if the region has zero peers in coordinator
+//                               metadata (no store to ask, so orphan status
+//                               cannot be verified via RPC).
+// Otherwise propagates the underlying VerifyPeersOnStore error verbatim, with a
+// hint to retry with --enable_store_verify=false to override.
+//
+// NOTE: this helper does NOT emit a log line itself. The returned Status carries
+// the full error_str; callers are expected to DINGO_LOG(ERROR) << <status>.error_str()
+// on failure. This avoids double-logging the same content from helper and caller.
+[[nodiscard]] butil::Status CheckRegionIsOrphanForDrop(std::shared_ptr<CoordinatorControl> coordinator_control,
+                                                      int64_t region_id) {
+  pb::coordinator_internal::RegionInternal region = coordinator_control->GetRegion(region_id);
+  if (region.id() == 0) {
+    return butil::Status(pb::error::Errno::EREGION_NOT_FOUND,
+                         fmt::format("DropRegionPermanently region not exists, id={}", region_id));
+  }
+
+  if (region.definition().peers_size() == 0) {
+    return butil::Status(
+        pb::error::Errno::EREGION_NOT_ORPHAN,
+        fmt::format("region:{} has no peers in coordinator metadata; cannot verify "
+                    "orphan status via store RPC. If you are certain the region's "
+                    "data is gone, pass --enable_store_verify=false to skip "
+                    "verification (DANGEROUS).",
+                    region_id));
+  }
+
+  // VerifyPeersOnStore populates two out-vectors: stores that confirm the
+  // region still exists, and stores that confirm absence. We use exist_store_ids
+  // to gate the NOT_ORPHAN refusal below; not_exist_store_ids is logged on the
+  // success path so operators can confirm which stores were actually reached.
+  std::vector<int64_t> exist_store_ids;
+  std::vector<int64_t> not_exist_store_ids;
+  butil::Status verify_status =
+      CoordinatorControl::VerifyPeersOnStore(region, exist_store_ids, not_exist_store_ids);
+  if (!verify_status.ok()) {
+    return butil::Status(
+        verify_status.error_code(),
+        fmt::format("verify peer on store failed: {}. Cannot determine whether region:{} is "
+                    "truly an orphan. If peer stores are confirmed offline / unreachable and "
+                    "you know the region's data is gone, pass --enable_store_verify=false "
+                    "to skip verification.",
+                    verify_status.error_str(), region_id));
+  }
+
+  if (!exist_store_ids.empty()) {
+    return butil::Status(
+        pb::error::Errno::EREGION_NOT_ORPHAN,
+        fmt::format("region:{} still exists on store_ids:[{}], this is NOT an orphan. "
+                    "DropRegionPermanently refused. If you are sure these stores no longer "
+                    "hold this region's data, pass --enable_store_verify=false to skip "
+                    "the check (DANGEROUS).",
+                    region_id, Helper::VectorToString(exist_store_ids)));
+  }
+
+  DINGO_LOG(INFO) << fmt::format(
+      "CheckRegionIsOrphanForDrop: region:{} confirmed orphan; stores reporting absence:[{}]",
+      region_id, Helper::VectorToString(not_exist_store_ids));
+
+  return butil::Status::OK();
+}
+
+}  // namespace
+
 void DoDropRegionPermanently(google::protobuf::RpcController * /*controller*/,
                              const pb::coordinator::DropRegionPermanentlyRequest *request,
                              pb::coordinator::DropRegionPermanentlyResponse *response, TrackClosure *done,
@@ -1478,7 +1551,46 @@ void DoDropRegionPermanently(google::protobuf::RpcController * /*controller*/,
   pb::coordinator_internal::MetaIncrement meta_increment;
 
   auto region_id = request->region_id();
-  auto cluster_id = request->cluster_id();
+  // cluster_id is currently unused but read to preserve the API surface;
+  // reserved for future multi-cluster routing.
+  [[maybe_unused]] auto cluster_id = request->cluster_id();
+
+  // Verify the region is truly an orphan (absent from all peer stores) before
+  // erasing coordinator metadata. proto3 default for enable_store_verify is
+  // false (old clients without the field stay on the no-verify path -- this
+  // is wire-level backward compat only); new dingodb_client / dingodb_cli set
+  // this to true by default. NOTE: backward compat here refers ONLY to the
+  // verify branch in this RPC handler. The underlying DropRegionPermanently
+  // has changed its state-gate predicate as part of this same change (it now
+  // emits DELETE for REGION_DELETED state to clean up heartbeat-driven shadow
+  // entries) -- see coordinator_control_coor.cc DropRegionPermanently().
+  //
+  // NOTE on TOCTOU: CheckRegionIsOrphanForDrop fans out to peer stores via
+  // VerifyPeersOnStore (ms-level RPC), and DropRegionPermanently below is NOT in
+  // the same critical section. A store could in principle re-report the region
+  // between check and erase. In practice this is acceptable because (a) a store
+  // that has "forgotten" the region does not spontaneously re-acquire it, and
+  // (b) this RPC is operator-initiated and is supposed to run only after all
+  // load on the region has stopped. Operators must not rely on this check to
+  // race against live traffic.
+  //
+  // When enable_store_verify=true, there is also a second TOCTOU window between
+  // the GetRegion(region_id) call inside CheckRegionIsOrphanForDrop and the
+  // region_map_.Get(region_id) call inside DropRegionPermanently itself (both
+  // are lock-free DingoSafeMap reads). The window is dominated by the
+  // VerifyPeersOnStore fan-out that sits between them, so it is ms-level under
+  // normal peer latency, not microseconds. If a raft apply erases the entry
+  // during that window, DropRegionPermanently returns EREGION_NOT_FOUND -- the
+  // operator just retries and sees the actual final state. No corruption risk.
+  if (request->enable_store_verify()) {
+    butil::Status orphan_check = CheckRegionIsOrphanForDrop(coordinator_control, region_id);
+    if (!orphan_check.ok()) {
+      DINGO_LOG(ERROR) << orphan_check.error_str();
+      response->mutable_error()->set_errcode(static_cast<pb::error::Errno>(orphan_check.error_code()));
+      response->mutable_error()->set_errmsg(orphan_check.error_str());
+      return;
+    }
+  }
 
   auto ret = coordinator_control->DropRegionPermanently(region_id, meta_increment);
 

--- a/test/unit_test/misc/test_drop_shadow_region.cc
+++ b/test/unit_test/misc/test_drop_shadow_region.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// =============================================================================
+// NOTE: DropRegionPermanently orphan-verification + state gate
+//
+// DoDropRegionPermanently (src/server/coordinator_service.cc) refuses to erase
+// coordinator metadata when --enable_store_verify=true and the region is still
+// reported by any peer store -- see CheckRegionIsOrphanForDrop. The underlying
+// state-gate predicate in CoordinatorControl::DropRegionPermanently emits a
+// DELETE op_type for REGION_DELETED entries (heartbeat-driven shadows) while
+// skipping REGION_DELETE / REGION_DELETING (already in flight) -- see
+// src/coordinator/coordinator_control_coor.cc.
+//
+// This behavior is validated end-to-end against a running coordinator via
+// dingodb_client / dingodb_cli. A unit-level test requires a CoordinatorControl
+// fixture (raft / kv dependencies) that is not yet available in this repo;
+// tracked as follow-up.
+//
+// E2E reproduction:
+//   ./dingodb_client --method=DropRegionPermanently --id=80002 --enable_store_verify=false
+//   ./dingodb_client --method=DropRegionPermanently --id=80001
+//   ./dingodb_client --method=DropRegionPermanently --id=80001 --enable_store_verify=false
+//   ./dingodb_client --method=DropRegionPermanently --id=80003
+//   ./dingodb_client --method=DropRegionPermanently --id=80004
+//
+//   ./dingodb_cli DropRegionPermanently --id=80002
+// =============================================================================

--- a/test/unit_test/misc/test_split_validation.cc
+++ b/test/unit_test/misc/test_split_validation.cc
@@ -140,17 +140,12 @@ class SplitKeyBoundaryValidationTest : public testing::Test {
   // Replicates the fixed boundary check from raft_apply_handler.cc:276 and :531.
   // Returns true if split_key is strictly between start_key and end_key.
   static bool IsSplitKeyValid(const std::string& split_key, const std::string& start_key, const std::string& end_key) {
-    if (split_key <= start_key || split_key >= end_key) {
-      return false;
-    }
-    return true;
+    return !(split_key <= start_key || split_key >= end_key);
   }
 };
 
 // split_key="C" is strictly between "B" and "D" — should be valid.
-TEST_F(SplitKeyBoundaryValidationTest, SplitKeyInMiddle_ShouldBeValid) {
-  EXPECT_TRUE(IsSplitKeyValid("C", "B", "D"));
-}
+TEST_F(SplitKeyBoundaryValidationTest, SplitKeyInMiddle_ShouldBeValid) { EXPECT_TRUE(IsSplitKeyValid("C", "B", "D")); }
 
 // split_key="B" equals start_key — should be rejected (the bug allowed this).
 TEST_F(SplitKeyBoundaryValidationTest, SplitKeyEqualToStartKey_ShouldBeRejected) {
@@ -269,3 +264,24 @@ TEST_F(SnapshotFailureCleanupTest, BothFlagsCleared_SimulatesSnapshotFailure) {
   EXPECT_FALSE(region->NeedBootstrapDoSnapshot());
   EXPECT_FALSE(region->TemporaryDisableChange());
 }
+
+// =============================================================================
+// NOTE: SplitRegion replica-status guard
+//
+// CoordinatorControl::SplitRegion / SplitRegionWithJob refuse the operation
+// when the parent (or an existing child) region's replica_status is not
+// REPLICA_NORMAL -- see CheckReplicaStatusForSplit in
+// src/coordinator/coordinator_control_coor.cc.
+//
+// This behavior is validated end-to-end against a running coordinator via
+// dingodb_cli. A unit-level test requires a CoordinatorControl fixture
+// (raft / kv dependencies) that is not yet available in this repo; tracked
+// as follow-up.
+//
+// E2E reproduction:
+//   ./dingodb_cli SplitRegion --split_from_id=80002 --store_create_region=true
+//
+// Setup: region 80002 is a degraded region whose replicas exist on only 2 of
+// the 3 stores (one peer is missing). The coordinator must refuse the split
+// because the parent replica_status is not REPLICA_NORMAL.
+// =============================================================================


### PR DESCRIPTION
[fix][coordinator] Resolved: If a shadows region appears, it can now be removed using DropRegionPermanently.
                           To ensure forward compatibility, a check for the existence of the store/index/document regions is required by default.
[fix][coordinator] Reject SplitRegion when parent or child replica is not normal to prevent shadows region on store.
[fix][conf] Remove the creation of the coordinator configuration upon enablement, as the coordinator never undergoes splitting.
[chore][git] Exclude the docs directory to facilitate the use of Claude Code.